### PR TITLE
Add GitHub Actions Workflow for Dockerfile linting

### DIFF
--- a/.github/workflows/lint-docker-files.yml
+++ b/.github/workflows/lint-docker-files.yml
@@ -1,0 +1,33 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-ci
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+name: Linting
+
+# Run builds for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  linting:
+    name: Lint Dockerfile files
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: index.docker.io/hadolint/hadolint:latest-debian
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.1
+
+      - name: Run hadolint against all Dockerfile files
+        run: |
+          hadolint stable/Dockerfile
+          hadolint oldstable/Dockerfile
+          hadolint unstable/Dockerfile


### PR DESCRIPTION
Use hadolint/hadolint Docker image to perform linting of the Dockerfile files used to build each of our
images.

refs:

- fixes GH-9
- https://github.com/hadolint/hadolint