### PR TITLE
Dependabot | Limit update series for "oldstable"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,13 @@ updates:
       interval: "daily"
       time: "02:00"
       timezone: "America/Chicago"
+    ignore:
+      - dependency-name: "golang"
+        # Ignore updates from series associated with "stable" container.
+        #
+        # Note: The version specified here should always be one ahead of the
+        # version used by the "oldstable" container.
+        versions: ["1.14.x"]
     assignees:
       - "atc0005"
     labels:


### PR DESCRIPTION
Attempt to limit updates to just the series associated
with this Dockerfile.

For example, GH-13 is for an update from 1.13.14 to
1.14.6. Instead, a fictional (as of this writing) update
to 1.13.15 should have been offered instead.

This line will need to be maintained between major
Go releases (and "old" stable versions being retired).

- refs GH-12
- refs GH-13