### PR TITLE
Fix linting-only image environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ listing of available container images.
 
 ### `go-ci-lint-only`
 
-- smallest image
-- based off of Alpine Linux
+- smaller image
+- uses `golangci/golangci-lint:vX.Y.Z-alpine` image as base
 - created as part of a multi-stage container build
 
 ## Examples / How to use these images
@@ -102,5 +102,7 @@ official release is also provided for further review.
   - <https://github.com/dominikh/go-tools>
   - <https://github.com/golangci/golangci-lint>
 
-- Building images
+- Images
   - <https://fabianlee.org/2020/01/26/golang-using-multi-stage-builds-to-create-clean-docker-images/>
+  - <https://hub.docker.com/r/golangci/golangci-lint>
+  - <https://hub.docker.com/_/golang>

--- a/stable/Dockerfile.linting
+++ b/stable/Dockerfile.linting
@@ -10,7 +10,8 @@
 
 
 # builder image
-FROM golang:1.14.6 as builder
+# use the same environment as our final image for binary compatibility
+FROM golangci/golangci-lint:v1.29.0-alpine as builder
 
 ENV GOLANGCI_LINT_VERSION v1.29.0
 ENV STATICCHECK_VERSION 2020.1.5
@@ -19,12 +20,12 @@ ENV STATICCHECK_VERSION 2020.1.5
 # and cleaning the modules cache takes extra time that won't help the final
 # linting-only image.
 RUN GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
-    && staticcheck --version \
-    && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-    && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
-    && golangci-lint --version
+    && staticcheck --version
 
 # For CI "linting only" use
-FROM alpine:3.12.0
-COPY --from=builder /go/bin/staticcheck .
-COPY --from=builder /go/bin/golangci-lint .
+FROM golangci/golangci-lint:v1.29.0-alpine
+
+# Intended to help identify the versions of the included linting tools
+ENV STATICCHECK_VERSION 2020.1.5
+
+COPY --from=builder /go/bin/staticcheck /usr/bin/staticcheck


### PR DESCRIPTION
## Problem

Unfortunately the last release used an Alpine Linux base image that was lacking required support for
the `net` package. I did not dig deep to discover the most optimal fix

## Changes

The workaround employed here is to switch the base image to the same Docker image provided by the `golangci-lint` project and just drop-in the `staticcheck` binary to complete our package.

While this does substantially increase the image size, it still weighs in a little less than the shared image used for other purposes.

This can be further researched at a later time.

## References

- fixes GH-19 
- refs GH-16 