### PR TITLE
Bundle golangci-lint, markdownlint config files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,36 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-ci
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+issues:
+  # equivalent CLI flag: --exclude-use-default
+  #
+  # see:
+  #   atc0005/todo#22
+  #   atc0005/todo#29
+  #   golangci-lint/golangci-lint#1249
+  #   golangci-lint/golangci-lint#413
+  exclude-use-default: false
+
+linters:
+  enable:
+    - dogsled
+    - goimports
+    - gosec
+    - stylecheck
+    - goconst
+    - depguard
+    - prealloc
+    - misspell
+    - maligned
+    - dupl
+    - unconvert
+    - gofmt
+    - golint
+    - gocritic
+    - scopelint
+    - govet
+    - staticcheck

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ clean:
 build:
 	@echo "Building Docker containers"
 
+	@echo "Bundle linter config files to provide baseline default settings"
+	@for version in {stable,oldstable,unstable}; do cp -vf .markdownlint.yml $$version/; done
+	@for version in {stable,oldstable,unstable}; do cp -vf .golangci.yml $$version/; done
+
 	@echo "Building stable release"
 	sudo docker build \
 		--no-cache \
@@ -99,6 +103,10 @@ build:
 		-t  $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_UNSTABLE) \
 		-t  $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_UNSTABLE)-$(REPO_VERSION) \
 		--label=$(DOCKER_IMAGE_LABEL)
+
+	@echo "Remove temporary copies of bundled files"
+	@rm -vf {stable,oldstable,unstable}/.markdownlint.yml
+	@rm -vf {stable,oldstable,unstable}/.golangci.yml
 
 	@echo "Finished building containers"
 

--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -27,3 +27,15 @@ RUN GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VER
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version
+
+# Copy over linting config files to root of container to serve as a default.
+# Projects bringing their own config files (e.g., via GitHub Actions) can
+# easily override these files, while projects choosing to use these config
+# files exclusively can omit their copy.
+#
+# These files are copied from the root of this repo alongside this Dockerfile
+# via Makefile `build` recipe. This allows for maintaining a single copy of
+# either file in this repo vs each Dockerfile build "context" having their own
+# separate copy.
+COPY .markdownlint.yml /
+COPY .golangci.yml /

--- a/stable/Dockerfile.combined
+++ b/stable/Dockerfile.combined
@@ -27,3 +27,15 @@ RUN GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VER
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version
+
+# Copy over linting config files to root of container to serve as a default.
+# Projects bringing their own config files (e.g., via GitHub Actions) can
+# easily override these files, while projects choosing to use these config
+# files exclusively can omit their copy.
+#
+# These files are copied from the root of this repo alongside this Dockerfile
+# via Makefile `build` recipe. This allows for maintaining a single copy of
+# either file in this repo vs each Dockerfile build "context" having their own
+# separate copy.
+COPY .markdownlint.yml /
+COPY .golangci.yml /

--- a/stable/Dockerfile.linting
+++ b/stable/Dockerfile.linting
@@ -29,3 +29,15 @@ FROM golangci/golangci-lint:v1.29.0-alpine
 ENV STATICCHECK_VERSION 2020.1.5
 
 COPY --from=builder /go/bin/staticcheck /usr/bin/staticcheck
+
+# Copy over linting config files to root of container to serve as a default.
+# Projects bringing their own config files (e.g., via GitHub Actions) can
+# easily override these files, while projects choosing to use these config
+# files exclusively can omit their copy.
+#
+# These files are copied from the root of this repo alongside this Dockerfile
+# via Makefile `build` recipe. This allows for maintaining a single copy of
+# either file in this repo vs each Dockerfile build "context" having their own
+# separate copy.
+COPY .markdownlint.yml /
+COPY .golangci.yml /

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -27,3 +27,15 @@ RUN GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VER
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version
+
+# Copy over linting config files to root of container to serve as a default.
+# Projects bringing their own config files (e.g., via GitHub Actions) can
+# easily override these files, while projects choosing to use these config
+# files exclusively can omit their copy.
+#
+# These files are copied from the root of this repo alongside this Dockerfile
+# via Makefile `build` recipe. This allows for maintaining a single copy of
+# either file in this repo vs each Dockerfile build "context" having their own
+# separate copy.
+COPY .markdownlint.yml /
+COPY .golangci.yml /


### PR DESCRIPTION
By including both of these config files at the root of the generated containers we provide a usable linting configuration baseline for all Go projects using these containers.

NOTE: As of this commit, markdownlint is not included in the containers generated by this project. This linter should be installed within an appropriate environment (e.g., via GitHub Actions) and then directed to use the
`.markdownlint.yml` file provided by this container.

fixes GH-32