### PR TITLE
Update oldstable container from 1.13.14 to 1.13.15

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.13.14
+FROM golang:1.13.15
 
 ENV GOLANGCI_LINT_VERSION v1.30.0
 ENV STATICCHECK_VERSION 2020.1.5


### PR DESCRIPTION
fixes GH-42