### PR TITLE
Update "unstable" container to Go 1.15rc2

### DIFF
--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15rc1
+FROM golang:1.15rc2
 
 ENV GOLANGCI_LINT_VERSION v1.30.0
 ENV STATICCHECK_VERSION 2020.1.5


### PR DESCRIPTION
fixes GH-46