### PR TITLE
docker: Update "oldstable" details

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,7 +72,7 @@ updates:
         #
         # Note: The version specified here should always be one ahead of the
         # version used by the "oldstable" container.
-        versions: ["1.14.x"]
+        versions: ["1.15.x"]
     assignees:
       - "atc0005"
     labels:

--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.13.15
+FROM golang:1.14.7
 
 ENV GOLANGCI_LINT_VERSION v1.30.0
 ENV STATICCHECK_VERSION 2020.1.5


### PR DESCRIPTION
- Switch from Go 1.13.x to 1.14.x series
- Attempt to exclude Go 1.15.x updates for this image

refs GH-50