### PR TITLE
Update "oldstable" Go version to 1.14.8

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.14.7
+FROM golang:1.14.8
 
 ENV GOLANGCI_LINT_VERSION v1.30.0
 ENV STATICCHECK_VERSION 2020.1.5


### PR DESCRIPTION
This coincides with the Go 1.15.1 release.