### PR TITLE
Sort golangci-lint linters list

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,22 +15,23 @@ issues:
   #   golangci-lint/golangci-lint#413
   exclude-use-default: false
 
+# Reminder: Sort this after every change
 linters:
   enable:
-    - dogsled
-    - goimports
-    - gosec
-    - stylecheck
-    - goconst
     - depguard
-    - prealloc
-    - misspell
-    - maligned
+    - dogsled
     - dupl
-    - unconvert
-    - gofmt
-    - golint
+    - goconst
     - gocritic
-    - scopelint
+    - gofmt
+    - goimports
+    - golint
+    - gosec
     - govet
+    - maligned
+    - misspell
+    - prealloc
+    - scopelint
     - staticcheck
+    - stylecheck
+    - unconvert


### PR DESCRIPTION
The goal is to make it easier to spot duplicate entries and to tell at a quick glance whether a linter is already enabled.