### PR TITLE
Clone golangci-lint config for "unstable" variant

### DIFF
--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -1,0 +1,44 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-ci
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+###############################################################################
+# NOTE: This is the golangci-lint configuration file *specific* to the
+# "unstable" variant of the containers provided by this project. This
+# configuration (potentially) enables additional linters not used by the other
+# container variants.
+###############################################################################
+
+issues:
+  # equivalent CLI flag: --exclude-use-default
+  #
+  # see:
+  #   atc0005/todo#22
+  #   atc0005/todo#29
+  #   golangci-lint/golangci-lint#1249
+  #   golangci-lint/golangci-lint#413
+  exclude-use-default: false
+
+# Reminder: Sort this after every change
+linters:
+  enable:
+    - depguard
+    - dogsled
+    - dupl
+    - goconst
+    - gocritic
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - govet
+    - maligned
+    - misspell
+    - prealloc
+    - scopelint
+    - staticcheck
+    - stylecheck
+    - unconvert

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -37,5 +37,11 @@ RUN GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VER
 # via Makefile `build` recipe. This allows for maintaining a single copy of
 # either file in this repo vs each Dockerfile build "context" having their own
 # separate copy.
-COPY .markdownlint.yml /
 COPY .golangci.yml /
+
+# This Dockerfile already has its own copy of the golangci-lint config file.
+# This local copy is manually synced from the main config file in order to
+# enable new checks for all containers, while enabling additional linters for
+# testing prior to enabling for all container variants. See also GH-63.
+#
+# COPY .markdownlint.yml /


### PR DESCRIPTION
This local copy of the config file can be extended without impacting the enabled linters (and linter settings) used by the other container variants.

fixes GH-63