### PR TITLE
Update README to mention unstable img linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,11 @@ listing of available container images.
 
 ### `go-ci-unstable`
 
-- built from the latest non-stable `golang:rc` image.
+- built from the latest available non-stable `golang:rc` image *or* if not
+  recently available, the latest stable `golang` image
 - used for building Go applications, both directly and via `Makefile` builds.
+- used to test new linters prior to inclusion in the `stable` and `oldstable`
+  container variants
 
 ### `go-ci-lint-only`
 


### PR DESCRIPTION
Note that the `unstable` variant will be used to test new
linters prior to inclusion in the other variants.

refs GH-64, GH-50