### PR TITLE
Update version range syntax for oldstable image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,7 +72,7 @@ updates:
         #
         # Note: The version specified here should always be one ahead of the
         # version used by the "oldstable" container.
-        versions: ["1.15.x"]
+        versions: ["1.15"]
     assignees:
       - "atc0005"
     labels:


### PR DESCRIPTION
Fix version range syntax per feedback from GH user jurre.

fixes GH-100
refs dependabot/dependabot-core 2644