### PR TITLE
Update Golang versions to 1.15.3 and 1.14.10

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.14.9
+FROM golang:1.14.10
 
 ENV GOLANGCI_LINT_VERSION="v1.31.0"
 ENV STATICCHECK_VERSION="2020.1.6"

--- a/stable/Dockerfile.alpine-build.x64
+++ b/stable/Dockerfile.alpine-build.x64
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15.2-alpine3.12
+FROM golang:1.15.3-alpine3.12
 
 # NOTE: This version was different than the base `gcc` pkg when last checked
 ENV APK_GCC_MINGW64_VERSION="9.3.0-r0"

--- a/stable/Dockerfile.combined
+++ b/stable/Dockerfile.combined
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15.2
+FROM golang:1.15.3
 
 ENV GOLANGCI_LINT_VERSION="v1.31.0"
 ENV STATICCHECK_VERSION="2020.1.6"

--- a/stable/Dockerfile.debian-build
+++ b/stable/Dockerfile.debian-build
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15.2
+FROM golang:1.15.3
 
 ENV GOLANGCI_LINT_VERSION="v1.31.0"
 ENV STATICCHECK_VERSION="2020.1.6"


### PR DESCRIPTION
The linting-only image will be updated once the upstream `golangci/golangci-lint` image is.

- fixes GH-102
- refs GH-98 (this same work, but incorrect image change)
