### PR TITLE
Update Go to versions 1.14.11 and 1.15.4

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.14.10
+FROM golang:1.14.11
 
 ENV GOLANGCI_LINT_VERSION="v1.32.2"
 ENV STATICCHECK_VERSION="2020.1.6"

--- a/stable/Dockerfile.alpine-build.x64
+++ b/stable/Dockerfile.alpine-build.x64
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15.3-alpine3.12
+FROM golang:1.15.4-alpine3.12
 
 # NOTE: This version was different than the base `gcc` pkg when last checked
 ENV APK_GCC_MINGW64_VERSION="9.3.0-r0"

--- a/stable/Dockerfile.combined
+++ b/stable/Dockerfile.combined
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15.3
+FROM golang:1.15.4
 
 ENV GOLANGCI_LINT_VERSION="v1.32.2"
 ENV STATICCHECK_VERSION="2020.1.6"

--- a/stable/Dockerfile.debian-build
+++ b/stable/Dockerfile.debian-build
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15.3
+FROM golang:1.15.4
 
 ENV GOLANGCI_LINT_VERSION="v1.32.2"
 ENV STATICCHECK_VERSION="2020.1.6"


### PR DESCRIPTION
The linting-only image will be updated once the upstream
`golangci/golangci-lint` image is.

fixes GH-120