### PR TITLE
Add orijtech/httperroryzer linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,14 @@ is useful to others.
 
 ## Linting tools included
 
+Primary:
+
 - [`staticcheck`](https://github.com/dominikh/go-tools)
 - [`golangci-lint`](https://github.com/golangci/golangci-lint)
+
+Additional:
+
+- [orijtech/httperroryzer](https://github.com/orijtech/httperroryzer)
 
 ## Docker images
 
@@ -60,7 +66,7 @@ listing of available container images.
 - used for building Go applications, both directly and via `Makefile` builds.
 - intended for use in a build/test matrix of prior, current and upcoming Go
   releases
-- provides multiple linters, including `golangci-lint`
+- provides multiple linters
   - see [Linting tools included](#linting-tools-included)
 
 ### `go-ci-stable-alpine-buildx86`
@@ -89,7 +95,7 @@ listing of available container images.
 - supports cross-platform, static cgo-enabled builds for Windows and Linux
   - Windows 32-bit: `i686-w64-mingw32-gcc`
   - Windows 64-bit: `x86_64-w64-mingw32-gcc`
-- provides multiple linters, including `golangci-lint`
+- provides multiple linters
   - see [Linting tools included](#linting-tools-included)
 
 ### `go-ci-oldstable`
@@ -98,7 +104,7 @@ listing of available container images.
 - used for building Go applications, both directly and via `Makefile` builds.
 - intended for use in a build/test matrix of prior, current and upcoming Go
   releases
-- provides multiple linters, including `golangci-lint`
+- provides multiple linters
   - see [Linting tools included](#linting-tools-included)
 
 ### `go-ci-unstable`
@@ -110,7 +116,7 @@ listing of available container images.
 - used for building Go applications, both directly and via `Makefile` builds
 - intended for use in a build/test matrix of prior, current and upcoming Go
   releases
-- provides multiple linters, including `golangci-lint`
+- provides multiple linters
   - see [Linting tools included](#linting-tools-included)
 - used to test new or additional `golangci-lint` linters prior to inclusion in
   the `stable` and `oldstable` container variants
@@ -127,7 +133,7 @@ listing of available container images.
   - e.g., testing or squash/rebase branch work prior to a full suite of checks
     usually associated with Pull Requests
 - limited linters
-  - `golangci-lint` is the sole linter provided
+  - [Primary linters only](#linting-tools-included)
 
 ## Examples / How to use these images
 
@@ -155,8 +161,11 @@ official release is also provided for further review.
 ## References
 
 - Linting
-  - <https://github.com/dominikh/go-tools>
-  - <https://github.com/golangci/golangci-lint>
+  - Primary
+    - [staticcheck](https://github.com/dominikh/go-tools)
+    - [golangci-lint](https://github.com/golangci/golangci-lint)
+  - Additional
+    - [orijtech/httperroryzer](https://github.com/orijtech/httperroryzer)
 
 - Images
   - <https://fabianlee.org/2020/01/26/golang-using-multi-stage-builds-to-create-clean-docker-images/>

--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -11,6 +11,7 @@ FROM golang:1.14.12
 
 ENV GOLANGCI_LINT_VERSION="v1.33.0"
 ENV STATICCHECK_VERSION="2020.1.6"
+ENV HTTPERRORYZER_VERSION="9d75de8cdf66f34670c84aeef3c2b698b001fd44"
 ENV APT_BSDMAINUTILS_VERSION="11.1.2+b1"
 ENV APT_TREE_VERSION="1.8.0-1"
 
@@ -23,10 +24,11 @@ RUN apt-get update \
 
 RUN GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
-    && go clean -cache -modcache \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
-    && golangci-lint --version
+    && golangci-lint --version \
+    && GO111MODULE="on" go get github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && go clean -cache -modcache
 
 # Copy over linting config files to root of container to serve as a default.
 # Projects bringing their own config files (e.g., via GitHub Actions) can

--- a/stable/Dockerfile.combined
+++ b/stable/Dockerfile.combined
@@ -11,6 +11,7 @@ FROM golang:1.15.5
 
 ENV GOLANGCI_LINT_VERSION="v1.33.0"
 ENV STATICCHECK_VERSION="2020.1.6"
+ENV HTTPERRORYZER_VERSION="9d75de8cdf66f34670c84aeef3c2b698b001fd44"
 ENV APT_BSDMAINUTILS_VERSION="11.1.2+b1"
 ENV APT_TREE_VERSION="1.8.0-1"
 
@@ -23,10 +24,11 @@ RUN apt-get update \
 
 RUN GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
-    && go clean -cache -modcache \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
-    && golangci-lint --version
+    && golangci-lint --version \
+    && GO111MODULE="on" go get github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && go clean -cache -modcache
 
 # Copy over linting config files to root of container to serve as a default.
 # Projects bringing their own config files (e.g., via GitHub Actions) can

--- a/stable/Dockerfile.debian-build
+++ b/stable/Dockerfile.debian-build
@@ -11,6 +11,7 @@ FROM golang:1.15.5
 
 ENV GOLANGCI_LINT_VERSION="v1.33.0"
 ENV STATICCHECK_VERSION="2020.1.6"
+ENV HTTPERRORYZER_VERSION="9d75de8cdf66f34670c84aeef3c2b698b001fd44"
 ENV APT_BSDMAINUTILS_VERSION="11.1.2+b1"
 ENV APT_TREE_VERSION="1.8.0-1"
 ENV APT_GCC_MULTILIB_VERSION="4:8.3.0-1"
@@ -27,10 +28,11 @@ RUN apt-get update \
 
 RUN GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
-    && go clean -cache -modcache \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
-    && golangci-lint --version
+    && golangci-lint --version \
+    && GO111MODULE="on" go get github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && go clean -cache -modcache
 
 # Copy over linting config files to root of container to serve as a default.
 # Projects bringing their own config files (e.g., via GitHub Actions) can

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -8,4 +8,7 @@ require (
 
 	// staticcheck - used in our containers
 	honnef.co/go/tools v0.0.1-2020.1.6
+
+	// httperroryzer - provided as an optional linter
+	github.com/orijtech/httperroryzer v0.0.0-20201128061256-9d75de8cdf66
 )

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -10,5 +10,6 @@ package tools
 // nolint
 import (
 	_ "github.com/golangci/golangci-lint/pkg/config"
+	_ "github.com/orijtech/httperroryzer"
 	_ "honnef.co/go/tools/config"
 )

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -11,6 +11,7 @@ FROM golang:1.15.5
 
 ENV GOLANGCI_LINT_VERSION="v1.33.0"
 ENV STATICCHECK_VERSION="2020.1.6"
+ENV HTTPERRORYZER_VERSION="9d75de8cdf66f34670c84aeef3c2b698b001fd44"
 ENV APT_BSDMAINUTILS_VERSION="11.1.2+b1"
 ENV APT_TREE_VERSION="1.8.0-1"
 
@@ -23,10 +24,11 @@ RUN apt-get update \
 
 RUN GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
-    && go clean -cache -modcache \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
-    && golangci-lint --version
+    && golangci-lint --version \
+    && GO111MODULE="on" go get github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && go clean -cache -modcache
 
 # Copy over linting config files to root of container to serve as a default.
 # Projects bringing their own config files (e.g., via GitHub Actions) can


### PR DESCRIPTION
- Update images to include new linter
  - commit 9d75de8cdf66f34670c84aeef3c2b698b001fd44
  - `httperroryzer` does not yet have a tag

- README tweaks
  - mention new linter
  - attempt to better phrase "multiple linters provided"

- Update tools/go.mod
  - lock in commit 9d75de8cdf66f34670c84aeef3c2b698b001fd44

fixes GH-139