### PR TITLE
Ignore scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ GH_TOKEN.txt
 
 # Ignore Visual Studio Code workspace-level settings
 /.vscode/settings.json
+
+# Ignore local "scratch" notes, temporary files, etc.
+/scratch


### PR DESCRIPTION
This is used to store local scratch notes, files that are not intended to be included in the repo.