### PR TITLE
Update ignore syntax for retired and newer Go vers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,8 +71,11 @@ updates:
         # Ignore updates from series associated with "stable" container.
         #
         # Note: The version specified here should always be one ahead of the
-        # version used by the "oldstable" container.
-        versions: ["1.15"]
+        # version used by the "oldstable" container. (GH-100)
+        # versions: ["1.15"]
+        versions:
+          - ">= 1.15"
+          - "< 1.14"
     assignees:
       - "atc0005"
     labels:


### PR DESCRIPTION
The previous attempt did not work, so trying different syntax to specify upper/lower bounds of Go versions that should not be suggested for the `oldstable` Docker image.

refs GH-100