### PR TITLE
Update tools/go.mod Go version from 1.13 to 1.14

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,11 +1,11 @@
 module github.com/atc0005/go-ci/tools
 
-go 1.13
+go 1.14
 
 require (
-
 	// errwrap - provided as an optional linter
 	github.com/fatih/errwrap v1.2.0
+
 	// golangci-lint - used in our containers
 	github.com/golangci/golangci-lint v1.33.0
 


### PR DESCRIPTION
- version bump
- whitespace tweaks

fixes GH-168
