### PR TITLE
Update unstable image to Go 1.16 Beta 1

### DIFF
--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15.6
+FROM golang:1.16beta1
 
 ENV GOLANGCI_LINT_VERSION="v1.33.0"
 ENV STATICCHECK_VERSION="v0.1.0"


### PR DESCRIPTION
The new image isn't yet available, so the image reference set in this commit hasn't been validated.

fixes GH-176