### PR TITLE
Update Go 1.15.6 to 1.15.7

### DIFF
--- a/stable/Dockerfile.alpine-build.x64
+++ b/stable/Dockerfile.alpine-build.x64
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15.6-alpine3.12
+FROM golang:1.15.7-alpine3.12
 
 # NOTE: This version was different than the base `gcc` pkg when last checked
 ENV APK_GCC_MINGW64_VERSION="9.3.0-r0"

--- a/stable/Dockerfile.combined
+++ b/stable/Dockerfile.combined
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15.6
+FROM golang:1.15.7
 
 ENV GOLANGCI_LINT_VERSION="v1.35.2"
 ENV STATICCHECK_VERSION="v0.1.0"

--- a/stable/Dockerfile.debian-build
+++ b/stable/Dockerfile.debian-build
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15.6
+FROM golang:1.15.7
 
 ENV GOLANGCI_LINT_VERSION="v1.35.2"
 ENV STATICCHECK_VERSION="v0.1.0"


### PR DESCRIPTION
Update images:

- `go-ci-stable-alpine-buildx64`
- `go-ci-stable`
- `go-ci-stable-debian-build`

The other images needing this update and Go 1.14.14 were
updated by Dependabot PRs.

The linting-only image will be updated once the upstream
`golangci/golangci-lint` image is.

fixes GH-203