### PR TITLE
Remove errwrap from oldstable image

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ is useful to others.
 
 ## Linting tools included
 
-| Linter                                                                | Version               |
-| --------------------------------------------------------------------- | --------------------- |
-| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2020.2.3` (`v0.1.3`) |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.39.0`             |
-| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`              |
-| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`              |
-| [`pelletier/go-toml/cmd/tomll`](https://github.com/pelletier/go-toml) | `v1.8.1`              |
-| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.3.1`              |
+| Linter                                                                | Version                                                                                  |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2020.2.3` (`v0.1.3`)                                                                    |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.39.0`                                                                                |
+| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`                                                                                 |
+| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`                                                                                 |
+| [`pelletier/go-toml/cmd/tomll`](https://github.com/pelletier/go-toml) | `v1.8.1`                                                                                 |
+| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.3.1` ([omitted from `oldstable` image](https://github.com/atc0005/go-ci/issues/280)) |
 
 ## Docker images
 

--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -14,7 +14,9 @@ ENV STATICCHECK_VERSION="v0.1.3"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
 ENV TOMLL_VERSION="v1.8.1"
-ENV ERRWRAP_VERSION="v1.3.1"
+
+# TODO: Re-enable once Go 1.17 is released and 1.16 is then the "oldstable" release
+# ENV ERRWRAP_VERSION="v1.3.1"
 
 ENV APT_BSDMAINUTILS_VERSION="11.1.2+b1"
 ENV APT_TREE_VERSION="1.8.0-1"
@@ -34,8 +36,10 @@ RUN GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VER
     && GO111MODULE="on" go get github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
     && GO111MODULE="on" go get github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
     && GO111MODULE="on" go get github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
-    && GO111MODULE="on" go get github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache
+
+# TODO: Re-enable once Go 1.17 is released and 1.16 is then the "oldstable" release
+#     && GO111MODULE="on" go get github.com/fatih/errwrap@${ERRWRAP_VERSION} \
 
 # Copy over linting config files to root of container to serve as a default.
 # Projects bringing their own config files (e.g., via GitHub Actions) can


### PR DESCRIPTION
The v1.3.1 version now requires Go 1.16 and the oldstable
image is based on Go 1.15. For now, disable including
errwrap in this image.

Update README to note that errwrap is not included in the
`oldstable` image.

fixes GH-280