### PR TITLE
Re-enable deprecated maligned linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,16 +29,28 @@ linters:
     - golint
     - gosec
     - govet
+
+    # Deprecated linter, but still functional as of golangci-lint v1.39.0.
+    # See https://github.com/atc0005/go-ci/issues/302 for more information.
+    - maligned
+
     - misspell
     - prealloc
     - staticcheck
     - stylecheck
     - unconvert
+#
+# Disable fieldalignment settings until the Go team offers more control over
+# the types of checks provided by the fieldalignment linter or golangci-lint
+# does so.
+#
+# See https://github.com/atc0005/go-ci/issues/302 for more information.
+#
 
-  disable:
-    - maligned
+# disable:
+# - maligned
 
-linters-settings:
-  govet:
-    enable:
-      - fieldalignment
+# linters-settings:
+# govet:
+#   enable:
+#     - fieldalignment

--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -40,14 +40,26 @@ linters:
     - golint
     - gosec
     - govet
+
+    # Deprecated linter, but still functional as of golangci-lint v1.39.0.
+    # See https://github.com/atc0005/go-ci/issues/302 for more information.
+    - maligned
+
     - misspell
     - prealloc
     - staticcheck
     - stylecheck
     - unconvert
 
-  disable:
-    - maligned
+#
+# Disable govet:fieldalignment, re-enable deprecated maligned linter until the
+# Go team offers more control over the types of checks provided by the
+# fieldalignment linter or golangci-lint does so.
+#
+# See https://github.com/atc0005/go-ci/issues/302 for more information.
+#
+# disable:
+#   - maligned
 
 linters-settings:
   gocognit:
@@ -57,7 +69,13 @@ linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 15
-
-  govet:
-    enable:
-      - fieldalignment
+#
+# Disable govet:fieldalignment, re-enable deprecated maligned linter until the
+# Go team offers more control over the types of checks provided by the
+# fieldalignment linter or golangci-lint does so.
+#
+# See https://github.com/atc0005/go-ci/issues/302 for more information.
+#
+# govet:
+#   enable:
+#     - fieldalignment


### PR DESCRIPTION
Disable govet:fieldalignment, re-enable deprecated maligned
linter until the Go team offers more control over the types
of checks provided by the fieldalignment linter or
golangci-lint does so.

refs GH-302