### PR TITLE
Resolve "DL3059 consecutive `RUN`" linting errors

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -26,9 +26,9 @@ RUN apt-get update \
     bsdmainutils=${APT_BSDMAINUTILS_VERSION} \
     tree=${APT_TREE_VERSION} \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \

--- a/stable/build/debian/Dockerfile
+++ b/stable/build/debian/Dockerfile
@@ -28,9 +28,9 @@ RUN apt-get update \
     gcc-multilib=${APT_GCC_MULTILIB_VERSION} \
     gcc-mingw-w64=${APT_GCC_MINGW_W64_VERSION} \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN GO111MODULE="on" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && GO111MODULE="on" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -24,9 +24,9 @@ RUN apt-get update \
     bsdmainutils=${APT_BSDMAINUTILS_VERSION} \
     tree=${APT_TREE_VERSION} \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN GO111MODULE="on" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && GO111MODULE="on" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -24,9 +24,9 @@ RUN apt-get update \
     bsdmainutils=${APT_BSDMAINUTILS_VERSION} \
     tree=${APT_TREE_VERSION} \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN GO111MODULE="on" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && GO111MODULE="on" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \


### PR DESCRIPTION
The intended visual separation of distinct "blocks" of tasks
are now achieved via an escaped newline instead of separate
RUN statements.

fixes GH-347