### PR TITLE
Update golangci-lint version in linters table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ The following types of changes will be recorded in this file:
 
 ## [Unreleased]
 
-- placeholder
+### Fixed
+
+- README
+  - Update `golangci/golangci-lint` linters table entry to reflect `v1.41.1`
+    release included in `v0.3.27` images
 
 ## [v0.3.27] - 2021-06-23
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ is useful to others.
 | Linter                                                                | Version                                                                                  |
 | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
 | [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2021.1` (`v0.2.0`)                                                                      |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.41.0`                                                                                |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.41.1`                                                                                |
 | [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`                                                                                 |
 | [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`                                                                                 |
 | [`pelletier/go-toml/cmd/tomll`](https://github.com/pelletier/go-toml) | `v1.9.3`                                                                                 |


### PR DESCRIPTION
I meant to include this in the last release, but mistakenly thought it was already done.

refs GH-356
