### PR TITLE
Switch Alpine build container images to 3.14 base

### DIFF
--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -7,19 +7,19 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.16.5-alpine3.12
+FROM golang:1.16.6-alpine3.14
 
 # NOTE: This version was different than the base `gcc` pkg when last checked
-ENV APK_GCC_MINGW64_VERSION="9.3.0-r0"
+ENV APK_GCC_MINGW64_VERSION="10.3.0-r0"
 
-ENV APK_BASH_VERSION="5.0.17-r0"
-ENV APK_GCC_VERSION="9.3.0-r2"
-ENV APK_GIT_VERSION="2.26.3-r0"
+ENV APK_BASH_VERSION="5.1.4-r0"
+ENV APK_GCC_VERSION="10.3.1_git20210424-r2"
+ENV APK_GIT_VERSION="2.32.0-r0"
 ENV APK_MAKE_VERSION="4.3-r0"
-ENV APK_UTIL_LINUX_VERSION="2.35.2-r0"
-ENV APK_FILE_VERSION="5.38-r0"
-ENV APK_NANO_VERSION="4.9.3-r0"
-ENV APK_MUSL_DEV_VERSION="1.1.24-r10"
+ENV APK_UTIL_LINUX_VERSION="2.37-r0"
+ENV APK_FILE_VERSION="5.40-r1"
+ENV APK_NANO_VERSION="5.7-r2"
+ENV APK_MUSL_DEV_VERSION="1.2.2-r3"
 
 # Install specific version of packages
 # RUN apk update && \

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -7,19 +7,19 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.16.5-alpine3.12
+FROM i386/golang:1.16.6-alpine3.14
 
 # NOTE: This version was different than the base `gcc` pkg when last checked
-ENV APK_GCC_MINGW64_VERSION="9.3.0-r0"
+ENV APK_GCC_MINGW64_VERSION="10.3.0-r0"
 
-ENV APK_BASH_VERSION="5.0.17-r0"
-ENV APK_GCC_VERSION="9.3.0-r2"
-ENV APK_GIT_VERSION="2.26.3-r0"
+ENV APK_BASH_VERSION="5.1.4-r0"
+ENV APK_GCC_VERSION="10.3.1_git20210424-r2"
+ENV APK_GIT_VERSION="2.32.0-r0"
 ENV APK_MAKE_VERSION="4.3-r0"
-ENV APK_UTIL_LINUX_VERSION="2.35.2-r0"
-ENV APK_FILE_VERSION="5.38-r0"
-ENV APK_NANO_VERSION="4.9.3-r0"
-ENV APK_MUSL_DEV_VERSION="1.1.24-r10"
+ENV APK_UTIL_LINUX_VERSION="2.37-r0"
+ENV APK_FILE_VERSION="5.40-r1"
+ENV APK_NANO_VERSION="5.7-r2"
+ENV APK_MUSL_DEV_VERSION="1.2.2-r3"
 
 # Install specific version of packages
 # RUN apk update && \


### PR DESCRIPTION
- `golang:1.16.5-alpine3.12` to `golang:1.16.6-alpine3.14`
- `i386/golang:1.16.5-alpine3.12` to `i386/golang:1.16.6-alpine3.14`

fixes GH-368