### PR TITLE
Remove `GO111MODULE` env var usage

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -26,15 +26,15 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \
-    && GO111MODULE="on" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+    && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version \
-    && GO111MODULE="on" go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
-    && GO111MODULE="on" go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
-    && GO111MODULE="on" go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
-    && GO111MODULE="on" go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
+    && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
+    && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache
 
 # Copy over linting config files to root of container to serve as a default.

--- a/stable/build/debian/Dockerfile
+++ b/stable/build/debian/Dockerfile
@@ -30,15 +30,15 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \
-    && GO111MODULE="on" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+    && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version \
-    && GO111MODULE="on" go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
-    && GO111MODULE="on" go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
-    && GO111MODULE="on" go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
-    && GO111MODULE="on" go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
+    && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
+    && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache
 
 # Copy over linting config files to root of container to serve as a default.

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -26,15 +26,15 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \
-    && GO111MODULE="on" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+    && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version \
-    && GO111MODULE="on" go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
-    && GO111MODULE="on" go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
-    && GO111MODULE="on" go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
-    && GO111MODULE="on" go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
+    && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
+    && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache
 
 # Copy over linting config files to root of container to serve as a default.

--- a/stable/linting/Dockerfile
+++ b/stable/linting/Dockerfile
@@ -18,7 +18,7 @@ ENV STATICCHECK_VERSION="v0.2.1"
 # Skip go clean step as the entire image will be tossed after we are finished
 # and cleaning the modules cache takes extra time that won't help the final
 # linting-only image.
-RUN GO111MODULE="on" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+RUN go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version
 
 # For CI "linting only" use

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -26,15 +26,15 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \
-    && GO111MODULE="on" go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+    && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version \
-    && GO111MODULE="on" go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
-    && GO111MODULE="on" go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
-    && GO111MODULE="on" go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
-    && GO111MODULE="on" go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
+    && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
+    && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache
 
 # Copy over linting config files to root of container to serve as a default.


### PR DESCRIPTION
Not needed as of Go 1.16 and Go 1.16 is now used in the `oldstable` image. Remove from all Dockerfiles.

fixes GH-402