### PR TITLE
Update `unstable` image to use Go 1.18beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ listing of available container images.
 
 ### `go-ci-unstable`
 
-- built from the latest available non-stable `golang:rc` image *or* if not
-  recently available, the latest stable `golang` image
+- built from the latest available non-stable `golang:beta` image, `golang:rc`
+  image *or* if not recently available, the latest stable `golang` image
   - intended to test whether new Go versions break existing code or surface
     problems in existing code that current Go releases do not
 - used for building Go applications, both directly and via `Makefile` builds

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.17.5
+FROM golang:1.18beta1
 
 ENV GOLANGCI_LINT_VERSION="v1.43.0"
 ENV STATICCHECK_VERSION="v0.2.2"


### PR DESCRIPTION
- switch `unsable` image from `golang:1.17.5` to
  `golang:1.18beta1`
- update README to indicate that the `unstable` image uses
  the latest `beta` image if available instead of only the
  latest `rc` or stable release

refs GH-464