### PR TITLE
Update unstable to build golangci-lint from src

### DIFF
--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -7,7 +7,26 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18beta1
+FROM golang:1.18beta1 as builder
+
+ENV GOLANGCI_LINT_VERSION="v1.43.0"
+ENV STATICCHECK_VERSION="v0.2.2"
+ENV HTTPERRORYZER_VERSION="v0.0.1"
+ENV STRUCTSLOP_VERSION="v0.0.6"
+ENV TOMLL_VERSION="v1.9.4"
+ENV ERRWRAP_VERSION="v1.3.1"
+
+RUN go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+    && staticcheck --version \
+    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION} \
+    && golangci-lint --version \
+    && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
+    && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && go install github.com/fatih/errwrap@${ERRWRAP_VERSION}
+
+
+FROM golang:1.18beta1 as final
 
 ENV GOLANGCI_LINT_VERSION="v1.43.0"
 ENV STATICCHECK_VERSION="v0.2.2"
@@ -24,18 +43,14 @@ RUN apt-get update \
     bsdmainutils=${APT_BSDMAINUTILS_VERSION} \
     tree=${APT_TREE_VERSION} \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    \
-    && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
-    && staticcheck --version \
-    && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-    && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
-    && golangci-lint --version \
-    && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
-    && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
-    && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
-    && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
-    && go clean -cache -modcache
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /go/bin/staticcheck /usr/bin/staticcheck
+COPY --from=builder /go/bin/golangci-lint /usr/bin/golangci-lint
+COPY --from=builder /go/bin/httperroryzer /usr/bin/httperroryzer
+COPY --from=builder /go/bin/structslop /usr/bin/structslop
+COPY --from=builder /go/bin/tomll /usr/bin/tomll
+COPY --from=builder /go/bin/errwrap /usr/bin/errwrap
 
 # Copy over linting config files to root of container to serve as a default.
 # Projects bringing their own config files (e.g., via GitHub Actions) can


### PR DESCRIPTION
- build golangci-lint from source
- split image creation into builder/final stages, copy
  Go binaries from builder stage into final

Brief testing has shown questionable results, but pushing this out anyway to gather live feedback from live CI tests/builds.

refs GH-464
