### PR TITLE
Enable `gochecknoglobals` linter

### DIFF
--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -30,6 +30,7 @@ linters:
     - dupl
     - exportloopref
     - errcheck
+    - gochecknoglobals
     - gocognit
     - goconst
     - gocritic


### PR DESCRIPTION
- Enable the `gochecknoglobals` golangci-lint linter
  in the `unstable` img (disabled by default)

fixes GH-483