### PR TITLE
Enable additional `govet` analyzers

### DIFF
--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -70,13 +70,16 @@ linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 15
-#
-# Disable govet:fieldalignment, re-enable deprecated maligned linter until the
-# Go team offers more control over the types of checks provided by the
-# fieldalignment linter or golangci-lint does so.
-#
-# See https://github.com/atc0005/go-ci/issues/302 for more information.
-#
-# govet:
-#   enable:
-#     - fieldalignment
+
+  govet:
+    enable-all: true
+
+    #
+    # Disable fieldalignment settings until the Go team offers more control over
+    # the types of checks provided by the fieldalignment linter or golangci-lint
+    # does so.
+    #
+    # See https://github.com/atc0005/go-ci/issues/302 for more information.
+    #
+    disable:
+      - fieldalignment


### PR DESCRIPTION
- explicitly disable `fieldalignment` analyzer
- enable all other `govet` analyzers
  - this also pulls in `nilness` and `shadow`, both of which
    has proven useful (brief testing)

fixes GH-482