### PR TITLE
Enable `gocyclo`, `gocognit`, `goerr113` linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,8 +22,11 @@ linters:
     - dogsled
     - dupl
     - exportloopref
+    - gocognit
     - goconst
     - gocritic
+    - gocyclo
+    - goerr113
     - gofmt
     - goimports
     - golint


### PR DESCRIPTION
All three linters have been used by the unstable image
since September 2020, so should be stable enough to
have enabled by default for the stable images.

fixes GH-486