### PR TITLE
Disable gocyclo, gocognit, goerr113 linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,11 +22,8 @@ linters:
     - dogsled
     - dupl
     - exportloopref
-    - gocognit
     - goconst
     - gocritic
-    - gocyclo
-    - goerr113
     - gofmt
     - goimports
     - gosec
@@ -57,12 +54,3 @@ linters:
 # govet:
 #   enable:
 #     - fieldalignment
-
-linters-settings:
-  gocognit:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 10
-
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 15


### PR DESCRIPTION
- stable image
- oldstable image

Reverts:

- commit 78baf5f956c547412681be784c835e4efde7925d
- commit 742a03ae50435845a15f6631ffa8e9dc46e10a94

fixes GH-494