### PR TITLE
Connect repo to Docker images

### DIFF
--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -9,6 +9,9 @@
 
 FROM golang:1.17.6-alpine3.14
 
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source=https://github.com/atc0005/go-ci
+
 # NOTE: This version was different than the base `gcc` pkg when last checked
 ENV APK_GCC_MINGW64_VERSION="10.3.0-r0"
 

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -9,6 +9,9 @@
 
 FROM i386/golang:1.17.6-alpine3.14
 
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source=https://github.com/atc0005/go-ci
+
 # NOTE: This version was different than the base `gcc` pkg when last checked
 ENV APK_GCC_MINGW64_VERSION="10.3.0-r0"
 

--- a/stable/build/debian/Dockerfile
+++ b/stable/build/debian/Dockerfile
@@ -9,6 +9,9 @@
 
 FROM golang:1.17.6
 
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source=https://github.com/atc0005/go-ci
+
 ENV GOLANGCI_LINT_VERSION="v1.44.0"
 ENV STATICCHECK_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="v0.0.1"

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -9,6 +9,9 @@
 
 FROM golang:1.17.6
 
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source=https://github.com/atc0005/go-ci
+
 ENV GOLANGCI_LINT_VERSION="v1.44.0"
 ENV STATICCHECK_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="v0.0.1"

--- a/stable/linting/Dockerfile
+++ b/stable/linting/Dockerfile
@@ -24,6 +24,9 @@ RUN go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
 # For CI "linting only" use
 FROM golangci/golangci-lint:v1.44.0-alpine
 
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source=https://github.com/atc0005/go-ci
+
 # Intended to help identify the versions of the included linting tools
 ENV GOLANGCI_LINT_VERSION="v1.44.0"
 ENV STATICCHECK_VERSION="v0.2.2"

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -28,6 +28,9 @@ RUN go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
 
 FROM golang:1.18beta2 as final
 
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source=https://github.com/atc0005/go-ci
+
 ENV GOLANGCI_LINT_VERSION="v1.44.0"
 ENV STATICCHECK_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="v0.0.1"


### PR DESCRIPTION
Use `org.opencontainers.image.source` LABEL to connect generated Docker images back to the source repo.

fixes GH-498