### PR TITLE
Connect repo to oldstable Docker image

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -9,6 +9,9 @@
 
 FROM golang:1.16.13
 
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source=https://github.com/atc0005/go-ci
+
 ENV GOLANGCI_LINT_VERSION="v1.44.0"
 ENV STATICCHECK_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="v0.0.1"


### PR DESCRIPTION
Use `org.opencontainers.image.source` LABEL to connect generated `oldstable` Docker image back to the source repo.

I missed updating the `oldstable` Dockerfile when I updated the others.

refs GH-498