### PR TITLE
Exclude non-stable updates for stable containers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,8 +82,6 @@ updates:
     labels:
       - "dependencies"
       - "CI"
-    allow:
-      - dependency-type: "all"
     commit-message:
       prefix: "docker"
 
@@ -100,8 +98,6 @@ updates:
     labels:
       - "dependencies"
       - "CI"
-    allow:
-      - dependency-type: "all"
     commit-message:
       prefix: "docker"
 
@@ -118,8 +114,6 @@ updates:
     labels:
       - "dependencies"
       - "CI"
-    allow:
-      - dependency-type: "all"
     commit-message:
       prefix: "docker"
 
@@ -136,8 +130,6 @@ updates:
     labels:
       - "dependencies"
       - "CI"
-    allow:
-      - dependency-type: "all"
     commit-message:
       prefix: "docker"
 
@@ -154,8 +146,6 @@ updates:
     labels:
       - "dependencies"
       - "CI"
-    allow:
-      - dependency-type: "all"
     commit-message:
       prefix: "docker"
 
@@ -172,8 +162,6 @@ updates:
     labels:
       - "dependencies"
       - "CI"
-    allow:
-      - dependency-type: "all"
     commit-message:
       prefix: "docker"
 
@@ -190,8 +178,6 @@ updates:
     labels:
       - "dependencies"
       - "CI"
-    allow:
-      - dependency-type: "all"
     commit-message:
       prefix: "docker"
 


### PR DESCRIPTION
Attempt 4. Remove a setting which might be allowing non-stable
container versions as valid.

refs GH-542