### PR TITLE
Disable staticcheck linter

### DIFF
--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -55,7 +55,9 @@ linters:
     - misspell
     - prealloc
     - revive
-    - staticcheck
+
+    # Incompatible with Go 1.18 (GH-568)
+    # - staticcheck
     - stylecheck
     - unconvert
 


### PR DESCRIPTION
This linter was already in the disable list, but was unintentionally left in the enable list which caused a settings conflict.

fixes GH-574