### PR TITLE
Disable incompatible go-critic analyzers

### DIFF
--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -117,3 +117,5 @@ linters-settings:
     disable:
       # Incompatible with Go 1.18 (GH-568)
       - hugeParam
+      - rangeValCopy
+      - typeDefFirst


### PR DESCRIPTION
- hugeParam (previously disabled)
- rangeValCopy
- typeDefFirst

fixes GH-575