### PR TITLE
Disable stylecheck linter

### DIFF
--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -58,7 +58,7 @@ linters:
 
     # Incompatible with Go 1.18 (GH-568)
     # - staticcheck
-    - stylecheck
+    # - stylecheck
     - unconvert
 
   disable:


### PR DESCRIPTION
This linter was already in the disable list, but was
unintentionally left in the enable list which caused a
settings conflict.

refs GH-583