### PR TITLE
Revert oldstable image to staticcheck v0.2.2

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -21,7 +21,7 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
 ENV GOLANGCI_LINT_VERSION="v1.45.2"
-ENV STATICCHECK_VERSION="v0.3.0"
+ENV STATICCHECK_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
 ENV TOMLL_VERSION="v1.9.4"


### PR DESCRIPTION
v0.3.0 is incompatible with Go 1.16, so we will need to freeze the staticheck release at v0.2.2 for now. Once we update the oldstable image to Go 1.17 we can then use the latest staticcheck version again.

fixes GH-588