### PR TITLE
Add debugging output for tooling installation

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -37,14 +37,20 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \
+    && echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
+    && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version \
+    && echo "Installing httperroryzer@${HTTPERRORYZER_VERSION}" \
     && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
     && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
+    && echo "Installing tomll@${TOMLL_VERSION}" \
     && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && echo "Installing errwrap@${ERRWRAP_VERSION}" \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache
 

--- a/stable/build/debian/Dockerfile
+++ b/stable/build/debian/Dockerfile
@@ -42,14 +42,20 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \
+    && echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
+    && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version \
+    && echo "Installing httperroryzer@${HTTPERRORYZER_VERSION}" \
     && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
     && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
+    && echo "Installing tomll@${TOMLL_VERSION}" \
     && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && echo "Installing errwrap@${ERRWRAP_VERSION}" \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache
 

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -37,14 +37,20 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \
+    && echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
+    && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version \
+    && echo "Installing httperroryzer@${HTTPERRORYZER_VERSION}" \
     && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
     && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
+    && echo "Installing tomll@${TOMLL_VERSION}" \
     && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && echo "Installing errwrap@${ERRWRAP_VERSION}" \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache
 

--- a/stable/linting/Dockerfile
+++ b/stable/linting/Dockerfile
@@ -20,8 +20,10 @@ ENV STATICCHECK_VERSION="v0.3.0"
 # Skip go clean step as the entire image will be tossed after we are finished
 # and cleaning the modules cache takes extra time that won't help the final
 # linting-only image.
-RUN go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
+    go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
+    && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -16,13 +16,19 @@ ENV STRUCTSLOP_VERSION="v0.0.6"
 ENV TOMLL_VERSION="v1.9.4"
 ENV ERRWRAP_VERSION="v1.4.0"
 
-RUN go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
+    && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
+    && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
     && go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version \
+    && echo "Installing httperroryzer@${HTTPERRORYZER_VERSION}" \
     && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+    && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
     && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
+    && echo "Installing tomll@${TOMLL_VERSION}" \
     && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && echo "Installing errwrap@${ERRWRAP_VERSION}" \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION}
 
 


### PR DESCRIPTION
Emit intent to install a speciifc tool and version prior to
doing so. This can help identify an installation failure
when future incompatibilities arise.

refs GH-588