### PR TITLE
Update README to note staticcheck versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ others.
 
 ## Linting tools included
 
-| Linter                                                                | Version             |
-| --------------------------------------------------------------------- | ------------------- |
-| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2022.1` (`v0.3.0`) |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.45.2`           |
-| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`            |
-| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`            |
-| [`pelletier/go-toml/cmd/tomll`](https://github.com/pelletier/go-toml) | `v1.9.4`            |
-| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`            |
+| Linter                                                                | Version                                                |
+| --------------------------------------------------------------------- | ------------------------------------------------------ |
+| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2022.1` (`v0.3.0`) for `unstable` and `stable` images |
+| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2021.1.2` (`v0.2.2`) for `oldstable` image            |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.45.2`                                              |
+| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`                                               |
+| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`                                               |
+| [`pelletier/go-toml/cmd/tomll`](https://github.com/pelletier/go-toml) | `v1.9.4`                                               |
+| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`                                               |
 
 ## Docker images
 


### PR DESCRIPTION
- v0.3.0 for current Go versions
- v0.2.2 for oldstable Go 1.16 version