### PR TITLE
Fix Alpine x86 Docker image version

### DIFF
--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.18.1-alpine3.14
+FROM i386/golang:1.17.9-alpine3.14
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
Use the intended Go 1.17.9 version instead of the incorrectly chosen 1.18.1 version (based on current Dependabot config).

fixes GH-605
refs GH-601