### PR TITLE
Update dep name for `stable/build/alpine-x86`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -189,7 +189,7 @@ updates:
     commit-message:
       prefix: "docker"
     ignore:
-      - dependency-name: "golang"
+      - dependency-name: "i386/golang"
         versions:
           # Temporarily restrict Go updates to just the 1.17 series until
           # golangci-lint fully supports Go 1.18.


### PR DESCRIPTION
Follow advice from Dependabot devs to use `i386/golang` dep name instead of generic `golang` dependency name. This is intended to fix dependency version constraints.

- refs GH-609
- refs GH-608