### PR TITLE
Lower version for i386/golang Docker image

### DIFF
--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.17.9-alpine3.14
+FROM i386/golang:1.17.8-alpine3.14
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
Drop from 1.17.9 to 1.17.8 in order to test Dependabot version constraints for updates.

refs GH-609