### PR TITLE
Enable staticcheck in golangci-lint unstable image

### DIFF
--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -55,9 +55,9 @@ linters:
     - misspell
     - prealloc
     - revive
+    - staticcheck
 
     # Incompatible with Go 1.18 (GH-568)
-    # - staticcheck
     # - stylecheck
     - unconvert
 
@@ -70,7 +70,6 @@ linters:
     - noctx
     - rowserrcheck
     - sqlclosecheck
-    - staticcheck
     - structcheck
     - stylecheck
     - tparallel


### PR DESCRIPTION
The staticcheck linter now supports Go 1.18. Re-enable so that it can be used by golangci-lint.

- fixes GH-622
- refs GH-568