### PR TITLE
Upgrade pelletier/go-toml from v1 to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ others.
 | [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.46.0`                                                |
 | [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`                                                 |
 | [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`                                                 |
-| [`pelletier/go-toml/cmd/tomll`](https://github.com/pelletier/go-toml) | `v1.9.5`                                                 |
+| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.0`                                                 |
 | [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`                                                 |
 
 ## Docker images

--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -24,7 +24,7 @@ ENV GOLANGCI_LINT_VERSION="v1.46.0"
 ENV STATICCHECK_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
-ENV TOMLL_VERSION="v1.9.5"
+ENV TOMLL_VERSION="v2.0.0"
 ENV ERRWRAP_VERSION="v1.4.0"
 
 ENV APT_BSDMAINUTILS_VERSION="12.1.7+nmu3"
@@ -49,7 +49,7 @@ RUN apt-get update \
     && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
     && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
     && echo "Installing tomll@${TOMLL_VERSION}" \
-    && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && go install github.com/pelletier/go-toml/v2/cmd/tomll@${TOMLL_VERSION} \
     && echo "Installing errwrap@${ERRWRAP_VERSION}" \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache

--- a/stable/build/debian/Dockerfile
+++ b/stable/build/debian/Dockerfile
@@ -25,7 +25,7 @@ ENV GOLANGCI_LINT_VERSION="v1.46.0"
 ENV STATICCHECK_VERSION="v0.3.1"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
-ENV TOMLL_VERSION="v1.9.5"
+ENV TOMLL_VERSION="v2.0.0"
 ENV ERRWRAP_VERSION="v1.4.0"
 
 ENV APT_BSDMAINUTILS_VERSION="12.1.7+nmu3"
@@ -54,7 +54,7 @@ RUN apt-get update \
     && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
     && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
     && echo "Installing tomll@${TOMLL_VERSION}" \
-    && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && go install github.com/pelletier/go-toml/v2/cmd/tomll@${TOMLL_VERSION} \
     && echo "Installing errwrap@${ERRWRAP_VERSION}" \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -24,7 +24,7 @@ ENV GOLANGCI_LINT_VERSION="v1.46.0"
 ENV STATICCHECK_VERSION="v0.3.1"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
-ENV TOMLL_VERSION="v1.9.5"
+ENV TOMLL_VERSION="v2.0.0"
 ENV ERRWRAP_VERSION="v1.4.0"
 
 ENV APT_BSDMAINUTILS_VERSION="12.1.7+nmu3"
@@ -49,7 +49,7 @@ RUN apt-get update \
     && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
     && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
     && echo "Installing tomll@${TOMLL_VERSION}" \
-    && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && go install github.com/pelletier/go-toml/v2/cmd/tomll@${TOMLL_VERSION} \
     && echo "Installing errwrap@${ERRWRAP_VERSION}" \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/orijtech/structslop v0.0.6
 
 	// tomll - provided as an optional linter
-	github.com/pelletier/go-toml v1.9.5
+	github.com/pelletier/go-toml/v2 v2.0.0
 
 	// staticcheck - intended as a primary linter
 	honnef.co/go/tools v0.3.1

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools
@@ -13,6 +14,6 @@ import (
 	_ "github.com/golangci/golangci-lint/pkg/config"
 	_ "github.com/orijtech/httperroryzer"
 	_ "github.com/orijtech/structslop"
-	_ "github.com/pelletier/go-toml"
+	_ "github.com/pelletier/go-toml/v2"
 	_ "honnef.co/go/tools/config"
 )

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -13,7 +13,7 @@ ENV GOLANGCI_LINT_VERSION="v1.46.0"
 ENV STATICCHECK_VERSION="v0.3.1"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
-ENV TOMLL_VERSION="v1.9.5"
+ENV TOMLL_VERSION="v2.0.0"
 ENV ERRWRAP_VERSION="v1.4.0"
 
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
@@ -27,7 +27,7 @@ RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
     && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
     && echo "Installing tomll@${TOMLL_VERSION}" \
-    && go install github.com/pelletier/go-toml/cmd/tomll@${TOMLL_VERSION} \
+    && go install github.com/pelletier/go-toml/v2/cmd/tomll@${TOMLL_VERSION} \
     && echo "Installing errwrap@${ERRWRAP_VERSION}" \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION}
 
@@ -50,7 +50,7 @@ ENV GOLANGCI_LINT_VERSION="v1.46.0"
 ENV STATICCHECK_VERSION="v0.3.1"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
-ENV TOMLL_VERSION="v1.9.5"
+ENV TOMLL_VERSION="v2.0.0"
 ENV ERRWRAP_VERSION="v1.4.0"
 
 ENV APT_BSDMAINUTILS_VERSION="12.1.7+nmu3"


### PR DESCRIPTION
- Update Dockerfile ENV values
- Update README tools version table
- Update `tools/go.mod` and `tools/tools.go` "canary" files

fixes GH-619
