### PR TITLE
Update Alpine images for Go 1.17.11 release

### DIFF
--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.17.10-alpine3.14
+FROM golang:1.17.11-alpine3.16
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -23,16 +23,16 @@ LABEL org.opencontainers.image.description="Docker container image used to build
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
 # NOTE: This version was different than the base `gcc` pkg when last checked
-ENV APK_GCC_MINGW64_VERSION="10.3.0-r0"
+ENV APK_GCC_MINGW64_VERSION="11.3.0-r0"
 
-ENV APK_BASH_VERSION="5.1.16-r0"
-ENV APK_GCC_VERSION="10.3.1_git20210424-r2"
-ENV APK_GIT_VERSION="2.32.1-r0"
+ENV APK_BASH_VERSION="5.1.16-r2"
+ENV APK_GCC_VERSION="11.2.1_git20220219-r2"
+ENV APK_GIT_VERSION="2.36.1-r0"
 ENV APK_MAKE_VERSION="4.3-r0"
-ENV APK_UTIL_LINUX_VERSION="2.37.4-r0"
-ENV APK_FILE_VERSION="5.40-r1"
-ENV APK_NANO_VERSION="5.7-r2"
-ENV APK_MUSL_DEV_VERSION="1.2.2-r3"
+ENV APK_UTIL_LINUX_VERSION="2.38-r1"
+ENV APK_FILE_VERSION="5.41-r0"
+ENV APK_NANO_VERSION="6.3-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.3-r0"
 
 # Install specific version of packages
 # RUN apk update && \

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.17.10-alpine3.14
+FROM i386/golang:1.17.11-alpine3.16
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -22,16 +22,16 @@ LABEL org.opencontainers.image.description="Docker container image used to build
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
 # NOTE: This version was different than the base `gcc` pkg when last checked
-ENV APK_GCC_MINGW64_VERSION="10.3.0-r0"
+ENV APK_GCC_MINGW64_VERSION="11.3.0-r0"
 
-ENV APK_BASH_VERSION="5.1.16-r0"
-ENV APK_GCC_VERSION="10.3.1_git20210424-r2"
-ENV APK_GIT_VERSION="2.32.1-r0"
+ENV APK_BASH_VERSION="5.1.16-r2"
+ENV APK_GCC_VERSION="11.2.1_git20220219-r2"
+ENV APK_GIT_VERSION="2.36.1-r0"
 ENV APK_MAKE_VERSION="4.3-r0"
-ENV APK_UTIL_LINUX_VERSION="2.37.4-r0"
-ENV APK_FILE_VERSION="5.40-r1"
-ENV APK_NANO_VERSION="5.7-r2"
-ENV APK_MUSL_DEV_VERSION="1.2.2-r3"
+ENV APK_UTIL_LINUX_VERSION="2.38-r1"
+ENV APK_FILE_VERSION="5.41-r0"
+ENV APK_NANO_VERSION="6.3-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.3-r0"
 
 # Install specific version of packages
 # RUN apk update && \


### PR DESCRIPTION
- switch from Go 1.17.10 to 1.17.11
- switch from Alpine 3.14 to 3.16
- update APK package versions to reflect current 3.16
  release versions

fixes GH-651