### PR TITLE
Go unstable=1.19, stable=1.18, oldstable=1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ clean:
 	@echo
 	@echo "Pruning all dangling images"
 	@sudo docker image prune --force
+	@echo
+	@ echo "Removing temporary copies of linter config files"
+	@rm -vf {oldstable,unstable,stable/linting,stable/combined,stable/build/debian}/.markdownlint.yml
+	@rm -vf {stable/linting,stable/combined,stable/build/debian}/.golangci.yml
 
 .PHONY: linting
 ## linting: lint all Dockerfiles
@@ -106,12 +110,12 @@ build:
 	@echo "Building Docker container images"
 
 	@echo "Bundle linter config files to provide baseline default settings"
-	@for version in {oldstable,unstable}; do cp -vf .markdownlint.yml $$version/; done
-	@for version in {stable/linting,stable/combined,stable/build/alpine-x64,stable/build/alpine-x86,stable/build/debian}; do cp -vf .markdownlint.yml $$version/; done
+	@for version in {oldstable,unstable,stable/linting,stable/combined,stable/build/debian}; do cp -vf .markdownlint.yml $$version/; done
 
-	# unstable container image has its own copy of this file
-	@cp -vf .golangci.yml oldstable/
-	@for version in {stable/linting,stable/combined,stable/build/alpine-x64,stable/build/alpine-x86,stable/build/debian}; do cp -vf .golangci.yml $$version/; done
+	# unstable container image has its own copy of the .golangci.yml file
+	# oldstable container image has its own copy of the .golangci.yml file
+	# stable container images share a copy of the .golangci.yml file
+	@for version in {stable/linting,stable/combined,stable/build/debian}; do cp -vf stable/.golangci.yml $$version/; done
 
 	@echo "List Docker version"
 	@docker version
@@ -223,10 +227,12 @@ build:
 		--label=$(DOCKER_IMAGE_CREATED_LABEL)
 
 	@echo "Remove temporary copies of bundled files"
-	@rm -vf {stable,oldstable,unstable}/.markdownlint.yml
+	@rm -vf {oldstable,unstable,stable/linting,stable/combined,stable/build/debian}/.markdownlint.yml
 
 	# unstable container image has its own copy of this file
-	@rm -vf {stable,oldstable}/.golangci.yml
+	# oldstable container image has its own copy of this file
+	# stable variants share a copy of this file
+	@rm -vf {stable/linting,stable/combined,stable/build/debian}/.golangci.yml
 
 	@echo "Finished building Docker container images"
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,14 @@ others.
 
 ## Linting tools included
 
-| Linter                                                                | Version                                                  |
-| --------------------------------------------------------------------- | -------------------------------------------------------- |
-| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2022.1.2` (`v0.3.2`) for `unstable` and `stable` images |
-| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2021.1.2` (`v0.2.2`) for `oldstable` image              |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.46.2`                                                |
-| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`                                                 |
-| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`                                                 |
-| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.1`                                                 |
-| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`                                                 |
+| Linter                                                                | Version               |
+| --------------------------------------------------------------------- | --------------------- |
+| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2022.1.2` (`v0.3.2`) |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.46.2`             |
+| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`              |
+| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`              |
+| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.1`              |
+| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`              |
 
 ## Docker images
 

--- a/oldstable/.golangci.yml
+++ b/oldstable/.golangci.yml
@@ -15,6 +15,13 @@ issues:
   #   golangci-lint/golangci-lint#413
   exclude-use-default: false
 
+run:
+  # Define the Go version limit.
+  # Mainly related to generics support in go1.18.
+  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
+  # https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+  go: "1.17"
+
 # Reminder: Sort this after every change
 linters:
   enable:

--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.16.15
+FROM golang:1.17.11
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -58,10 +58,5 @@ RUN apt-get update \
 # default. Projects bringing their own config files (e.g., via GitHub Actions)
 # can easily override these files, while projects choosing to use these config
 # files exclusively can omit their copy.
-#
-# These files are copied from the root of this repo alongside this Dockerfile
-# via Makefile `build` recipe. This allows for maintaining a single copy of
-# either file in this repo vs each Dockerfile build "context" having their own
-# separate copy.
 COPY .markdownlint.yml /
 COPY .golangci.yml /

--- a/stable/.golangci.yml
+++ b/stable/.golangci.yml
@@ -27,8 +27,6 @@ run:
   # Mainly related to generics support in go1.18.
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
   # https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
-  #
-  # TODO: Update to 1.19 as soon as the value is supported by golangci-lint
   go: "1.18"
 
 # Reminder: Sort this after every change

--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.17.11-alpine3.16
+FROM golang:1.18.3-alpine3.16
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.17.11-alpine3.16
+FROM i386/golang:1.18.3-alpine3.16
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/debian/Dockerfile
+++ b/stable/build/debian/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.17.11
+FROM golang:1.18.3
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -59,14 +59,18 @@ RUN apt-get update \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
     && go clean -cache -modcache
 
-# Copy over linting config files to root of container to serve as a default.
+# Copy over linting config files to root of container image to serve as a
+# default. The Makefile copies in these files as Docker requires that the
+# source path for the files be inside the context of the build.
+#
+# From the official documentation:
+#
+# "you cannot COPY ../something /something, because the first step of a docker
+# build is to send the context directory (and subdirectories) to the docker
+# daemon.""
+#
 # Projects bringing their own config files (e.g., via GitHub Actions) can
 # easily override these files, while projects choosing to use these config
 # files exclusively can omit their copy.
-#
-# These files are copied from the root of this repo alongside this Dockerfile
-# via Makefile `build` recipe. This allows for maintaining a single copy of
-# either file in this repo vs each Dockerfile build "context" having their own
-# separate copy.
 COPY .markdownlint.yml /
 COPY .golangci.yml /

--- a/stable/build/mirror/Dockerfile
+++ b/stable/build/mirror/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.17.11
+FROM golang:1.18.3
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.17.11
+FROM golang:1.18.3
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -55,13 +55,17 @@ RUN apt-get update \
     && go clean -cache -modcache
 
 # Copy over linting config files to root of container image to serve as a
-# default. Projects bringing their own config files (e.g., via GitHub Actions)
-# can easily override these files, while projects choosing to use these config
-# files exclusively can omit their copy.
+# default. The Makefile copies in these files as Docker requires that the
+# source path for the files be inside the context of the build.
 #
-# These files are copied from the root of this repo alongside this Dockerfile
-# via Makefile `build` recipe. This allows for maintaining a single copy of
-# either file in this repo vs each Dockerfile build "context" having their own
-# separate copy.
+# From the official documentation:
+#
+# "you cannot COPY ../something /something, because the first step of a docker
+# build is to send the context directory (and subdirectories) to the docker
+# daemon.""
+#
+# Projects bringing their own config files (e.g., via GitHub Actions) can
+# easily override these files, while projects choosing to use these config
+# files exclusively can omit their copy.
 COPY .markdownlint.yml /
 COPY .golangci.yml /

--- a/stable/linting/Dockerfile
+++ b/stable/linting/Dockerfile
@@ -12,7 +12,7 @@
 # builder image
 # use the same environment as our final image for binary compatibility
 # FROM golangci/golangci-lint:v1.45.0-alpine as builder
-FROM golang:1.17.11 as builder
+FROM golang:1.18.3 as builder
 
 ENV GOLANGCI_LINT_VERSION="v1.46.2"
 ENV STATICCHECK_VERSION="v0.3.2"
@@ -30,7 +30,7 @@ RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
 
 # For CI "linting only" use
 # FROM golangci/golangci-lint:v1.45.0-alpine
-FROM golang:1.17.11 as final
+FROM golang:1.18.3 as final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -52,13 +52,17 @@ COPY --from=builder /go/bin/golangci-lint /usr/bin/golangci-lint
 COPY --from=builder /go/bin/staticcheck /usr/bin/staticcheck
 
 # Copy over linting config files to root of container image to serve as a
-# default. Projects bringing their own config files (e.g., via GitHub Actions)
-# can easily override these files, while projects choosing to use these config
-# files exclusively can omit their copy.
+# default. The Makefile copies in these files as Docker requires that the
+# source path for the files be inside the context of the build.
 #
-# These files are copied from the root of this repo alongside this Dockerfile
-# via Makefile `build` recipe. This allows for maintaining a single copy of
-# either file in this repo vs each Dockerfile build "context" having their own
-# separate copy.
+# From the official documentation:
+#
+# "you cannot COPY ../something /something, because the first step of a docker
+# build is to send the context directory (and subdirectories) to the docker
+# daemon.""
+#
+# Projects bringing their own config files (e.g., via GitHub Actions) can
+# easily override these files, while projects choosing to use these config
+# files exclusively can omit their copy.
 COPY .markdownlint.yml /
 COPY .golangci.yml /

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,7 @@
 module github.com/atc0005/go-ci/tools
 
-go 1.15
+// Use the current stable Go version
+go 1.18
 
 require (
 	// errwrap - provided as an optional linter

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18.3 as builder
+FROM golang:1.19beta1 as builder
 
 ENV GOLANGCI_LINT_VERSION="v1.46.2"
 ENV STATICCHECK_VERSION="v0.3.2"
@@ -32,7 +32,7 @@ RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION}
 
 
-FROM golang:1.18.3 as final
+FROM golang:1.19beta1 as final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -70,9 +70,9 @@ COPY --from=builder /go/bin/structslop /usr/bin/structslop
 COPY --from=builder /go/bin/tomll /usr/bin/tomll
 COPY --from=builder /go/bin/errwrap /usr/bin/errwrap
 
-# Copy over linting config files to root of  image to serve as a default.
-# Projects bringing their own config files (e.g., via GitHub Actions) can
-# easily override these files, while projects choosing to use these config
+# Copy over linting config files to root of container image to serve as a
+# default. Projects bringing their own config files (e.g., via GitHub Actions)
+# can easily override these files, while projects choosing to use these config
 # files exclusively can omit their copy.
 #
 # The Markdown linting config file is copied from the root of this repo


### PR DESCRIPTION
CHANGES

- each image type (`stable`, `unstable`, `oldstable`) has their own
  copy of the golangci-lint config file with the `stable` variants
  being given a copy of the via the Makefile build recipe
- each image type (`stable`, `unstable`, `oldstable`) is given a copy
  of the markdownlint config file via Makefile build recipe
- Makefile clean recipe updated to remove temporary copies of linter
	config files
- Makefile build recipe updated to limit copying of linter config
  files to just the images which use them
- `oldstable` image
  - explicitly specifies the Go version limit for golangci-lint as Go
    1.17
  - updated Go from `1.16.15` to `1.17.11`
- `unstable` image
  - explicitly specifies the Go version limit for golangci-lint as Go
    1.18 (for now)
  - updated Go from `1.18.3` to `1.19beta1`
- `stable` image
  - variants providing the golangci-lint linter explicitly specify the
    Go version limit for golangci-lint as Go 1.18
  - updated Go from `1.17.11` to `1.18.3`
- update README to drop compatibility notes regarding the `oldstable`
  image and older `staticcheck` version used for Go 1.16 compatibility
- update go.mod file to reflect current stable version of Go (1.18)
  with a note to update the version going forward

refs GH-557
refs GH-656