### PR TITLE
Update disabled linters for current 1.18 compatibility

### DIFF
--- a/stable/.golangci.yml
+++ b/stable/.golangci.yml
@@ -56,10 +56,7 @@ linters:
     - prealloc
     - revive
     - staticcheck
-
-    # Incompatible with Go 1.18 (GH-568)
-    # https://github.com/golangci/golangci-lint/issues/2649
-    # - stylecheck
+    - stylecheck
     - unconvert
 
   disable:
@@ -67,16 +64,13 @@ linters:
     # https://github.com/golangci/golangci-lint/issues/2649
     - bodyclose
     - contextcheck
-    - gosimple
     - nilerr
     - noctx
     - rowserrcheck
     - sqlclosecheck
     - structcheck
-    - stylecheck
     - tparallel
     - unparam
-    - unused
     - wastedassign
 
 #

--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -58,10 +58,7 @@ linters:
     - prealloc
     - revive
     - staticcheck
-
-    # Incompatible with Go 1.18 (GH-568)
-    # https://github.com/golangci/golangci-lint/issues/2649
-    # - stylecheck
+    - stylecheck
     - unconvert
 
   disable:
@@ -69,16 +66,13 @@ linters:
     # https://github.com/golangci/golangci-lint/issues/2649
     - bodyclose
     - contextcheck
-    - gosimple
     - nilerr
     - noctx
     - rowserrcheck
     - sqlclosecheck
     - structcheck
-    - stylecheck
     - tparallel
     - unparam
-    - unused
     - wastedassign
 
 #


### PR DESCRIPTION
Remove from disabled list:

- `gosimple`
- `stylecheck`
- `unused`

Return to explicitly enabled list:

- `stylecheck`

fixes GH-658