### PR TITLE
Revert stable image linters to original list

### DIFF
--- a/stable/.golangci.yml
+++ b/stable/.golangci.yml
@@ -36,13 +36,8 @@ linters:
     - dogsled
     - dupl
     - exportloopref
-    - errcheck
-    - gochecknoglobals
-    - gocognit
     - goconst
     - gocritic
-    - gocyclo
-    - goerr113
     - gofmt
     - goimports
     - gosec
@@ -84,14 +79,6 @@ linters:
 #   - maligned
 
 linters-settings:
-  gocognit:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 10
-
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 15
-
   govet:
     enable-all: true
     disable:


### PR DESCRIPTION
As part of promoting the versions of Go used in each image
type the linters enabled for the unstable image were ported
as-is to the stable container.

This commit reverts the unintended changes restoring the
original list of linters used by the unstable image.

Specifically:

- errcheck
- gochecknoglobals
- gocognit
- gocyclo
- goerr113

refs GH-557
refs GH-656
refs GH-658