### PR TITLE
Update Go images to 1.18.4 and 1.17.12

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.17.11
+FROM golang:1.17.12
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18.3-alpine3.16
+FROM golang:1.18.4-alpine3.16
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -27,7 +27,7 @@ ENV APK_GCC_MINGW64_VERSION="11.3.0-r0"
 
 ENV APK_BASH_VERSION="5.1.16-r2"
 ENV APK_GCC_VERSION="11.2.1_git20220219-r2"
-ENV APK_GIT_VERSION="2.36.1-r0"
+ENV APK_GIT_VERSION="2.36.2-r0"
 ENV APK_MAKE_VERSION="4.3-r0"
 ENV APK_UTIL_LINUX_VERSION="2.38-r1"
 ENV APK_FILE_VERSION="5.41-r0"

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.18.3-alpine3.16
+FROM i386/golang:1.18.4-alpine3.16
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -26,7 +26,7 @@ ENV APK_GCC_MINGW64_VERSION="11.3.0-r0"
 
 ENV APK_BASH_VERSION="5.1.16-r2"
 ENV APK_GCC_VERSION="11.2.1_git20220219-r2"
-ENV APK_GIT_VERSION="2.36.1-r0"
+ENV APK_GIT_VERSION="2.36.2-r0"
 ENV APK_MAKE_VERSION="4.3-r0"
 ENV APK_UTIL_LINUX_VERSION="2.38-r1"
 ENV APK_FILE_VERSION="5.41-r0"

--- a/stable/build/debian/Dockerfile
+++ b/stable/build/debian/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18.3
+FROM golang:1.18.4
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/mirror/Dockerfile
+++ b/stable/build/mirror/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18.3
+FROM golang:1.18.4
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18.3
+FROM golang:1.18.4
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/linting/Dockerfile
+++ b/stable/linting/Dockerfile
@@ -12,7 +12,7 @@
 # builder image
 # use the same environment as our final image for binary compatibility
 # FROM golangci/golangci-lint:v1.45.0-alpine as builder
-FROM golang:1.18.3 as builder
+FROM golang:1.18.4 as builder
 
 ENV GOLANGCI_LINT_VERSION="v1.46.2"
 ENV STATICCHECK_VERSION="v0.3.2"
@@ -30,7 +30,7 @@ RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
 
 # For CI "linting only" use
 # FROM golangci/golangci-lint:v1.45.0-alpine
-FROM golang:1.18.3 as final
+FROM golang:1.18.4 as final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
- update 1.17.11 to 1.17.12
- update 1.18.3 to 1.18.4
- update git APK package version to
  reflect version available in recent
  base image release

fixes GH-672