### PR TITLE
Refresh disabled linters for golangci-lint v1.47.0

### DIFF
--- a/stable/.golangci.yml
+++ b/stable/.golangci.yml
@@ -47,20 +47,6 @@ linters:
     - stylecheck
     - unconvert
 
-  disable:
-    # Incompatible with Go 1.18 (GH-568)
-    # https://github.com/golangci/golangci-lint/issues/2649
-    - bodyclose
-    - contextcheck
-    - nilerr
-    - noctx
-    - rowserrcheck
-    - sqlclosecheck
-    - structcheck
-    - tparallel
-    - unparam
-    - wastedassign
-
 #
 # Disable govet:fieldalignment, re-enable deprecated maligned linter until the
 # Go team offers more control over the types of checks provided by the

--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -61,20 +61,6 @@ linters:
     - stylecheck
     - unconvert
 
-  disable:
-    # Incompatible with Go 1.18 (GH-568)
-    # https://github.com/golangci/golangci-lint/issues/2649
-    - bodyclose
-    - contextcheck
-    - nilerr
-    - noctx
-    - rowserrcheck
-    - sqlclosecheck
-    - structcheck
-    - tparallel
-    - unparam
-    - wastedassign
-
 #
 # Disable govet:fieldalignment, re-enable deprecated maligned linter until the
 # Go team offers more control over the types of checks provided by the


### PR DESCRIPTION
- remove `disable` block from unstable config file
- remove `disable` block from stable config file

Some linter analyzers are still disabled pending resolution
from upstream projects.

fixes GH-676
refs golangci/golangci-lint#2649