### PR TITLE
Refresh disabled linters for golangci-lint v1.47.1

### DIFF
--- a/stable/.golangci.yml
+++ b/stable/.golangci.yml
@@ -47,6 +47,14 @@ linters:
     - stylecheck
     - unconvert
 
+  disable:
+    # Incompatible with Go 1.18 (GH-568, GH-681)
+    # https://github.com/golangci/golangci-lint/issues/2649
+    - rowserrcheck
+    - sqlclosecheck
+    - structcheck
+    - wastedassign
+
 #
 # Disable govet:fieldalignment, re-enable deprecated maligned linter until the
 # Go team offers more control over the types of checks provided by the

--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -61,6 +61,14 @@ linters:
     - stylecheck
     - unconvert
 
+  disable:
+    # Incompatible with Go 1.18 (GH-568, GH-681)
+    # https://github.com/golangci/golangci-lint/issues/2649
+    - rowserrcheck
+    - sqlclosecheck
+    - structcheck
+    - wastedassign
+
 #
 # Disable govet:fieldalignment, re-enable deprecated maligned linter until the
 # Go team offers more control over the types of checks provided by the


### PR DESCRIPTION
- restore `disable` block in unstable config file
  - add `rowserrcheck`
  - add `sqlclosecheck`
  - add `structcheck`
  - add `wastedassign`
- restore `disable` block in stable config file
  - add `rowserrcheck`
  - add `sqlclosecheck`
  - add `structcheck`
  - add `wastedassign`

fixes GH-681