### PR TITLE
README: Update pelletier/go-toml to v2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ others.
 | [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.48.0`             |
 | [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`              |
 | [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`              |
-| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.1`              |
+| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.2`              |
 | [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`              |
 
 ## Docker images


### PR DESCRIPTION
Update version entry to reflect the last update.

refs GH-663
