### PR TITLE
Downgrade golangci-lint from v1.48.0 to v1.47.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ others.
 | Linter                                                                | Version               |
 | --------------------------------------------------------------------- | --------------------- |
 | [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2022.1.3` (`v0.3.3`) |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.48.0`             |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.47.3`             |
 | [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`              |
 | [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`              |
 | [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.2`              |

--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -20,7 +20,7 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
     Based on the latest version of the current outgoing stable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
-ENV GOLANGCI_LINT_VERSION="v1.48.0"
+ENV GOLANGCI_LINT_VERSION="v1.47.3"
 ENV STATICCHECK_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"

--- a/stable/build/debian/Dockerfile
+++ b/stable/build/debian/Dockerfile
@@ -21,7 +21,7 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
     cgo-enabled builds via mingw."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
-ENV GOLANGCI_LINT_VERSION="v1.48.0"
+ENV GOLANGCI_LINT_VERSION="v1.47.3"
 ENV STATICCHECK_VERSION="v0.3.3"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -20,7 +20,7 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
     Based on the latest version of the current stable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
-ENV GOLANGCI_LINT_VERSION="v1.48.0"
+ENV GOLANGCI_LINT_VERSION="v1.47.3"
 ENV STATICCHECK_VERSION="v0.3.3"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"

--- a/stable/linting/Dockerfile
+++ b/stable/linting/Dockerfile
@@ -14,7 +14,7 @@
 # FROM golangci/golangci-lint:v1.45.0-alpine as builder
 FROM golang:1.18.5 as builder
 
-ENV GOLANGCI_LINT_VERSION="v1.48.0"
+ENV GOLANGCI_LINT_VERSION="v1.47.3"
 ENV STATICCHECK_VERSION="v0.3.3"
 
 # Skip go clean step as the entire image will be tossed after we are finished
@@ -45,7 +45,7 @@ LABEL org.opencontainers.image.description="Docker image intended for lightweigh
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
 # Intended to help identify the versions of the included linting tools
-ENV GOLANGCI_LINT_VERSION="v1.48.0"
+ENV GOLANGCI_LINT_VERSION="v1.47.3"
 ENV STATICCHECK_VERSION="v0.3.3"
 
 COPY --from=builder /go/bin/golangci-lint /usr/bin/golangci-lint

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -9,7 +9,7 @@
 
 FROM golang:1.19.0 as builder
 
-ENV GOLANGCI_LINT_VERSION="v1.48.0"
+ENV GOLANGCI_LINT_VERSION="v1.47.3"
 ENV STATICCHECK_VERSION="v0.3.3"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
@@ -46,7 +46,7 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
     golang:rc image or if not recently available, the latest stable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
-ENV GOLANGCI_LINT_VERSION="v1.48.0"
+ENV GOLANGCI_LINT_VERSION="v1.47.3"
 ENV STATICCHECK_VERSION="v0.3.3"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"


### PR DESCRIPTION
Downgrade golangci-lint to avoid Go 1.19 gofmt linting rules from being applied when an earlier version of Go is used.

fixes GH-699