### PR TITLE
Update images to use current Go versions

### DIFF
--- a/oldstable/.golangci.yml
+++ b/oldstable/.golangci.yml
@@ -18,9 +18,9 @@ issues:
 run:
   # Define the Go version limit.
   # Mainly related to generics support in go1.18.
-  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
+  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
   # https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
-  go: "1.17"
+  go: "1.18"
 
 # Reminder: Sort this after every change
 linters:
@@ -46,18 +46,55 @@ linters:
     - staticcheck
     - stylecheck
     - unconvert
+
+  disable:
+    # Incompatible with Go 1.18 (GH-568, GH-681)
+    # https://github.com/golangci/golangci-lint/issues/2649
+    - rowserrcheck
+    - sqlclosecheck
+    - structcheck
+    - wastedassign
+
 #
-# Disable fieldalignment settings until the Go team offers more control over
-# the types of checks provided by the fieldalignment linter or golangci-lint
-# does so.
+# Disable govet:fieldalignment, re-enable deprecated maligned linter until the
+# Go team offers more control over the types of checks provided by the
+# fieldalignment linter or golangci-lint does so.
 #
 # See https://github.com/atc0005/go-ci/issues/302 for more information.
 #
-
 # disable:
-# - maligned
+#   - maligned
 
-# linters-settings:
-# govet:
-#   enable:
-#     - fieldalignment
+linters-settings:
+  govet:
+    # Wait until after Go 1.19 is out and/or I have sufficient time to update
+    # projects dependent on these containers.
+    #
+    # See also:
+    #
+    # https://github.com/atc0005/go-ci/issues/666
+    #
+    # enable-all: true
+    disable:
+      #
+      # Disable fieldalignment settings until the Go team offers more control over
+      # the types of checks provided by the fieldalignment linter or golangci-lint
+      # does so.
+      #
+      # See https://github.com/atc0005/go-ci/issues/302 for more information.
+      #
+      - fieldalignment
+
+      # Incompatible with Go 1.18 (GH-568)
+      # https://github.com/golangci/golangci-lint/issues/2649
+      - nilness
+      - unusedwrite
+
+  gocritic:
+    disable:
+      # Incompatible with Go 1.18 (GH-568)
+      # https://github.com/golangci/golangci-lint/issues/2649
+      - hugeParam
+      - rangeValCopy
+      - typeDefFirst
+      - paramTypeCombine

--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.17.13
+FROM golang:1.18.5
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/.golangci.yml
+++ b/stable/.golangci.yml
@@ -18,9 +18,9 @@ issues:
 run:
   # Define the Go version limit.
   # Mainly related to generics support in go1.18.
-  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
+  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
   # https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
-  go: "1.18"
+  go: "1.19"
 
 # Reminder: Sort this after every change
 linters:

--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18.5-alpine3.16
+FROM golang:1.19.0-alpine3.16
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.18.5-alpine3.16
+FROM i386/golang:1.19.0-alpine3.16
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/debian/Dockerfile
+++ b/stable/build/debian/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18.5
+FROM golang:1.19.0
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/mirror/Dockerfile
+++ b/stable/build/mirror/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18.5
+FROM golang:1.19.0
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18.5
+FROM golang:1.19.0
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/linting/Dockerfile
+++ b/stable/linting/Dockerfile
@@ -12,7 +12,7 @@
 # builder image
 # use the same environment as our final image for binary compatibility
 # FROM golangci/golangci-lint:v1.45.0-alpine as builder
-FROM golang:1.18.5 as builder
+FROM golang:1.19.0 as builder
 
 ENV GOLANGCI_LINT_VERSION="v1.49.0"
 ENV STATICCHECK_VERSION="v0.3.3"
@@ -30,7 +30,7 @@ RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
 
 # For CI "linting only" use
 # FROM golangci/golangci-lint:v1.45.0-alpine
-FROM golang:1.18.5 as final
+FROM golang:1.19.0 as final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,7 +1,7 @@
 module github.com/atc0005/go-ci/tools
 
 // Use the current stable Go version
-go 1.18
+go 1.19
 
 require (
 	// errwrap - provided as an optional linter

--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -25,11 +25,9 @@ issues:
 run:
   # Define the Go version limit.
   # Mainly related to generics support in go1.18.
-  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
+  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
   # https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
-  #
-  # TODO: Update to 1.19 as soon as the value is supported by golangci-lint
-  go: "1.18"
+  go: "1.19"
 
 # Reminder: Sort this after every change
 linters:

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -20,7 +20,8 @@ RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
     && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
-    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION} \
+    && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+    && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version \
     && echo "Installing httperroryzer@${HTTPERRORYZER_VERSION}" \
     && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \


### PR DESCRIPTION
- update go.mod from Go 1.18 to current stable 1.19
- update oldstable image
  - switch base image (Dockerfile) from Go 1.17.13 to 1.18.5
  - swap Go 1.17 for 1.18 in golangci-lint config
  - sync Go 1.18+ linting settings from stable image
    - disable incompatible linters
    - add various doc comments regarding compatibility status
- update stable images
  - switch base image (Dockerfile) from Go 1.18.5 to 1.19.0
  - swap Go 1.18 for 1.19 in golangci-lint config
- update unstable image
  - switch from building golangci-lint to using official install.sh
    script
  - swap Go 1.18 for 1.19 in golangci-lint config

fixes GH-698