### PR TITLE
Update staticcheck version used in oldstable image

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -21,7 +21,7 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
 ENV GOLANGCI_LINT_VERSION="v1.49.0"
-ENV STATICCHECK_VERSION="v0.2.2"
+ENV STATICCHECK_VERSION="v0.3.3"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
 ENV TOMLL_VERSION="v2.0.4"


### PR DESCRIPTION
This was missed when staticcheck was last updated for all images.

- fixes GH-711
- refs GH-693