### PR TITLE
Remove explicit Go version used by golangci-lint

### DIFF
--- a/oldstable/.golangci.yml
+++ b/oldstable/.golangci.yml
@@ -15,12 +15,12 @@ issues:
   #   golangci-lint/golangci-lint#413
   exclude-use-default: false
 
-run:
-  # Define the Go version limit.
-  # Mainly related to generics support in go1.18.
-  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
-  # https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
-  go: "1.18"
+# run:
+# Define the Go version limit.
+# Mainly related to generics support in go1.18.
+# Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+# go: "1.18"
 
 # Reminder: Sort this after every change
 linters:

--- a/stable/.golangci.yml
+++ b/stable/.golangci.yml
@@ -15,12 +15,12 @@ issues:
   #   golangci-lint/golangci-lint#413
   exclude-use-default: false
 
-run:
-  # Define the Go version limit.
-  # Mainly related to generics support in go1.18.
-  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
-  # https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
-  go: "1.19"
+# run:
+# Define the Go version limit.
+# Mainly related to generics support in go1.18.
+# Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+# go: "1.19"
 
 # Reminder: Sort this after every change
 linters:

--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -22,12 +22,12 @@ issues:
   #   golangci-lint/golangci-lint#413
   exclude-use-default: false
 
-run:
-  # Define the Go version limit.
-  # Mainly related to generics support in go1.18.
-  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
-  # https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
-  go: "1.19"
+# run:
+# Define the Go version limit.
+# Mainly related to generics support in go1.18.
+# Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+# go: "1.19"
 
 # Reminder: Sort this after every change
 linters:


### PR DESCRIPTION
If not explicitly not, golangci-lint will use the available go.mod file to determine what Go features and applicable linting rules to use.

For example, if the project specifies Go 1.14 as the target Go version, golangci-lint will not issue a warning if the io/ioutil package is used (deprecated in Go 1.16).

fixes GH-716