### PR TITLE
Split makefile build recipe into sub recipes, call each from GHAW

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,8 +16,8 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  build_images_using_makefile:
-    name: Build images using Makefile
+  build_all_images_using_makefile:
+    name: Build all images using Makefile
     runs-on: ubuntu-latest
     # Default: 360 minutes
     timeout-minutes: 10
@@ -35,3 +35,163 @@ jobs:
 
       - name: Build images using project Makefile
         run: make build
+
+  build_stable_image_using_makefile:
+    name: Build stable image using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Print Docker version
+        run: docker --version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Build stable image
+        run: make build-stable
+
+  build_alpine_x64_image_using_makefile:
+    name: Build Alpine x64 image using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Print Docker version
+        run: docker --version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Build Alpine x64 image
+        run: make build-stable-alpine-buildx64
+
+  build_alpine_x86_image_using_makefile:
+    name: Build Alpine x86 image using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Print Docker version
+        run: docker --version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Build Alpine x86 image
+        run: make build-stable-alpine-buildx86
+
+  build_stable_debian_image_using_makefile:
+    name: Build stable Debian image using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Print Docker version
+        run: docker --version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Build stable Debian image
+        run: make stable-debian-build
+
+  build_stable_mirror_image_using_makefile:
+    name: Build stable mirror image using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Print Docker version
+        run: docker --version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Build stable mirror image
+        run: make stable-mirror-build
+
+  build_stable_linting_only_image_using_makefile:
+    name: Build stable linting-only image using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Print Docker version
+        run: docker --version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Build stable linting-only image
+        run: make stable-linting-only
+
+  build_oldstable_image_using_makefile:
+    name: Build oldstable image using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Print Docker version
+        run: docker --version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Build oldstable image
+        run: make build-oldstable
+
+  build_unstable_image_using_makefile:
+    name: Build unstable image using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Print Docker version
+        run: docker --version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Build unstable image
+        run: make build-unstable

--- a/Makefile
+++ b/Makefile
@@ -104,21 +104,9 @@ linting:
 		docker run --pull never --rm -i -v "$$PWD/$$target:$$PWD/$$target" $(DOCKER_IMAGE_HADOLINT) hadolint $$PWD/$$target; \
 	done
 
-.PHONY: build
-## build: build all Docker container images
-build:
-	@echo "Building Docker container images"
-
-	@echo "Bundle linter config files to provide baseline default settings"
-	@for version in {oldstable,unstable,stable/linting,stable/combined,stable/build/debian}; do cp -vf .markdownlint.yml $$version/; done
-
-	# unstable container image has its own copy of the .golangci.yml file
-	# oldstable container image has its own copy of the .golangci.yml file
-	# stable container images share a copy of the .golangci.yml file
-	@for version in {stable/linting,stable/combined,stable/build/debian}; do cp -vf stable/.golangci.yml $$version/; done
-
-	@echo "List Docker version"
-	@docker version
+.PHONY: build-stable
+## build-stable: Build stable image
+build-stable: pre-build
 
 	@echo "Building stable release"
 	sudo docker image build \
@@ -134,8 +122,13 @@ build:
 		--label=$(DOCKER_IMAGE_OWNER_LABEL) \
 		--label=$(DOCKER_IMAGE_REVISION_LABEL) \
 		--label=$(DOCKER_IMAGE_CREATED_LABEL)
+	@echo "Completed build of stable release"
 
-	@echo "Building stable-alpine-build.x64 release"
+.PHONY: build-stable-alpine-buildx64
+## build-stable-alpine-buildx64: Build Alpine x64 image
+build-stable-alpine-buildx64: pre-build
+
+	@echo "Building stable-alpine-buildx64 release"
 	sudo docker image build \
 		--pull \
 		--no-cache \
@@ -147,8 +140,13 @@ build:
 		--label=$(DOCKER_IMAGE_OWNER_LABEL) \
 		--label=$(DOCKER_IMAGE_REVISION_LABEL) \
 		--label=$(DOCKER_IMAGE_CREATED_LABEL)
+	@echo "Completed build of stable-alpine-buildx64 release"
 
-	@echo "Building stable-alpine-build x86 release"
+.PHONY: build-stable-alpine-buildx86
+## build-stable-alpine-buildx86: Build Alpine x86 image
+build-stable-alpine-buildx86: pre-build
+
+	@echo "Building stable-alpine-buildx86 release"
 	sudo docker image build \
 		--pull \
 		--no-cache \
@@ -160,6 +158,11 @@ build:
 		--label=$(DOCKER_IMAGE_OWNER_LABEL) \
 		--label=$(DOCKER_IMAGE_REVISION_LABEL) \
 		--label=$(DOCKER_IMAGE_CREATED_LABEL)
+	@echo "Completed build of stable-alpine-buildx86 release"
+
+.PHONY: stable-debian-build
+## stable-debian-build: Build Debian image
+stable-debian-build: pre-build
 
 	@echo "Building stable-debian-build release"
 	sudo docker image build \
@@ -173,6 +176,11 @@ build:
 		--label=$(DOCKER_IMAGE_OWNER_LABEL) \
 		--label=$(DOCKER_IMAGE_REVISION_LABEL) \
 		--label=$(DOCKER_IMAGE_CREATED_LABEL)
+	@echo "Completed build of stable-debian-build release"
+
+.PHONY: stable-mirror-build
+## stable-mirror-build: Build stable mirror image
+stable-mirror-build: pre-build
 
 	@echo "Building stable-mirror-build release"
 	sudo docker image build \
@@ -186,6 +194,11 @@ build:
 		--label=$(DOCKER_IMAGE_OWNER_LABEL) \
 		--label=$(DOCKER_IMAGE_REVISION_LABEL) \
 		--label=$(DOCKER_IMAGE_CREATED_LABEL)
+	@echo "Completed build of stable-mirror-build release"
+
+.PHONY: stable-linting-only
+## stable-linting-only: Build stable linting-only image
+stable-linting-only: pre-build
 
 	@echo "Building stable linting-only release"
 	sudo docker image build \
@@ -199,6 +212,11 @@ build:
 		--label=$(DOCKER_IMAGE_OWNER_LABEL) \
 		--label=$(DOCKER_IMAGE_REVISION_LABEL) \
 		--label=$(DOCKER_IMAGE_CREATED_LABEL)
+	@echo "Completed build of stable-linting-only release"
+
+.PHONY: build-oldstable
+## build-oldstable: Build oldstable image
+build-oldstable: pre-build
 
 	@echo "Building oldstable release"
 	sudo docker image build \
@@ -212,6 +230,11 @@ build:
 		--label=$(DOCKER_IMAGE_OWNER_LABEL) \
 		--label=$(DOCKER_IMAGE_REVISION_LABEL) \
 		--label=$(DOCKER_IMAGE_CREATED_LABEL)
+	@echo "Completed build of oldstable release"
+
+.PHONY: build-unstable
+## build-unstable: Build unstable image
+build-unstable: pre-build
 
 	@echo "Building unstable release"
 	sudo docker image build \
@@ -225,6 +248,29 @@ build:
 		--label=$(DOCKER_IMAGE_OWNER_LABEL) \
 		--label=$(DOCKER_IMAGE_REVISION_LABEL) \
 		--label=$(DOCKER_IMAGE_CREATED_LABEL)
+	@echo "Completed build of unstable release"
+
+.PHONY: pre-build
+## pre-build: pre-build tasks
+pre-build:
+
+	@echo "Building Docker container images"
+
+	@echo "Bundle linter config files to provide baseline default settings"
+	@for version in {oldstable,unstable,stable/linting,stable/combined,stable/build/debian}; do cp -vf .markdownlint.yml $$version/; done
+
+	# unstable container image has its own copy of the .golangci.yml file
+	# oldstable container image has its own copy of the .golangci.yml file
+	# stable container images share a copy of the .golangci.yml file
+	@for version in {stable/linting,stable/combined,stable/build/debian}; do cp -vf stable/.golangci.yml $$version/; done
+
+	@echo "List Docker version"
+	@docker version
+
+
+.PHONY: build
+## build: build all Docker container images
+build: pre-build build-stable build-stable-alpine-buildx64 build-stable-alpine-buildx86 stable-debian-build stable-mirror-build stable-linting-only build-oldstable build-unstable
 
 	@echo "Remove temporary copies of bundled files"
 	@rm -vf {oldstable,unstable,stable/linting,stable/combined,stable/build/debian}/.markdownlint.yml


### PR DESCRIPTION
- Split Makefile build task into sub-recipes
  - Allow building specific images by request and continue to support building all images via the existing `build` recipe.
- Update GHAW to call specific subrecipes
  - Continue to call combined "build everything" recipe, but add additional job entries in the `Build images` GHAW to call each separate image build subrecipe.