### PR TITLE
Add govulncheck command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ others.
 
 ## Linting tools included
 
-| Linter                                                                | Version               |
-| --------------------------------------------------------------------- | --------------------- |
-| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2022.1.3` (`v0.3.3`) |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.49.0`             |
-| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`              |
-| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`              |
-| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.5`              |
-| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`              |
+| Linter                                                                | Version                              |
+| --------------------------------------------------------------------- | ------------------------------------ |
+| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2022.1.3` (`v0.3.3`)                |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.49.0`                            |
+| [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `v0.0.0-20220908210932-64dbbd7bba4f` |
+| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`                             |
+| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.6`                             |
+| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.5`                             |
+| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`                             |
 
 ## Docker images
 
@@ -176,6 +177,7 @@ official release is also provided for further review.
   - Primary
     - [staticcheck](https://github.com/dominikh/go-tools)
     - [golangci-lint](https://github.com/golangci/golangci-lint)
+    - [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)
   - Additional
     - [orijtech/httperroryzer](https://github.com/orijtech/httperroryzer)
     - [orijtech/structslop](https://github.com/orijtech/structslop)

--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -22,6 +22,7 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
 ENV GOLANGCI_LINT_VERSION="v1.49.0"
 ENV STATICCHECK_VERSION="v0.3.3"
+ENV GOVULNCHECK_VERSION="v0.0.0-20220908210932-64dbbd7bba4f"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
 ENV TOMLL_VERSION="v2.0.5"
@@ -40,6 +41,8 @@ RUN apt-get update \
     && echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
+    && echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
+    && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
     && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \

--- a/stable/build/debian/Dockerfile
+++ b/stable/build/debian/Dockerfile
@@ -23,6 +23,7 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
 ENV GOLANGCI_LINT_VERSION="v1.49.0"
 ENV STATICCHECK_VERSION="v0.3.3"
+ENV GOVULNCHECK_VERSION="v0.0.0-20220908210932-64dbbd7bba4f"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
 ENV TOMLL_VERSION="v2.0.5"
@@ -45,6 +46,8 @@ RUN apt-get update \
     && echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
+    && echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
+    && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
     && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -22,6 +22,7 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
 ENV GOLANGCI_LINT_VERSION="v1.49.0"
 ENV STATICCHECK_VERSION="v0.3.3"
+ENV GOVULNCHECK_VERSION="v0.0.0-20220908210932-64dbbd7bba4f"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
 ENV TOMLL_VERSION="v2.0.5"
@@ -40,6 +41,8 @@ RUN apt-get update \
     && echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
+    && echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
+    && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
     && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \

--- a/stable/linting/Dockerfile
+++ b/stable/linting/Dockerfile
@@ -16,6 +16,7 @@ FROM golang:1.19.1 as builder
 
 ENV GOLANGCI_LINT_VERSION="v1.49.0"
 ENV STATICCHECK_VERSION="v0.3.3"
+ENV GOVULNCHECK_VERSION="v0.0.0-20220908210932-64dbbd7bba4f"
 
 # Skip go clean step as the entire image will be tossed after we are finished
 # and cleaning the modules cache takes extra time that won't help the final
@@ -23,6 +24,8 @@ ENV STATICCHECK_VERSION="v0.3.3"
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
+    && echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
+    && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
     && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
@@ -47,9 +50,11 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 # Intended to help identify the versions of the included linting tools
 ENV GOLANGCI_LINT_VERSION="v1.49.0"
 ENV STATICCHECK_VERSION="v0.3.3"
+ENV GOVULNCHECK_VERSION="v0.0.0-20220908210932-64dbbd7bba4f"
 
 COPY --from=builder /go/bin/golangci-lint /usr/bin/golangci-lint
 COPY --from=builder /go/bin/staticcheck /usr/bin/staticcheck
+COPY --from=builder /go/bin/govulncheck /usr/bin/govulncheck
 
 # Copy over linting config files to root of container image to serve as a
 # default. The Makefile copies in these files as Docker requires that the

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -18,6 +18,9 @@ require (
 	// tomll - provided as an optional linter
 	github.com/pelletier/go-toml/v2 v2.0.5
 
+	// govulncheck - provided as an optional vulnerability analyzer
+	golang.org/x/vuln v0.0.0-20220908210932-64dbbd7bba4f
+
 	// staticcheck - intended as a primary linter
 	honnef.co/go/tools v0.3.3
 )
@@ -48,10 +51,11 @@ require (
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/stretchr/testify v1.8.0 // indirect
 	github.com/subosito/gotenv v1.4.0 // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/tools v0.1.12 // indirect
+	golang.org/x/tools v0.1.13-0.20220803210227-8b9a1fbdf5c3 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -15,5 +15,6 @@ import (
 	_ "github.com/orijtech/httperroryzer"
 	_ "github.com/orijtech/structslop"
 	_ "github.com/pelletier/go-toml/v2"
+	_ "golang.org/x/vuln/vulncheck"
 	_ "honnef.co/go/tools/config"
 )

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -11,6 +11,7 @@ FROM golang:1.19.1 as builder
 
 ENV GOLANGCI_LINT_VERSION="v1.49.0"
 ENV STATICCHECK_VERSION="v0.3.3"
+ENV GOVULNCHECK_VERSION="v0.0.0-20220908210932-64dbbd7bba4f"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
 ENV TOMLL_VERSION="v2.0.5"
@@ -19,6 +20,8 @@ ENV ERRWRAP_VERSION="v1.4.0"
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version \
+    && echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
+    && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
     && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
     && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
@@ -49,6 +52,7 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
 ENV GOLANGCI_LINT_VERSION="v1.49.0"
 ENV STATICCHECK_VERSION="v0.3.3"
+ENV GOVULNCHECK_VERSION="v0.0.0-20220908210932-64dbbd7bba4f"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.6"
 ENV TOMLL_VERSION="v2.0.5"
@@ -66,6 +70,7 @@ RUN apt-get update \
 
 COPY --from=builder /go/bin/staticcheck /usr/bin/staticcheck
 COPY --from=builder /go/bin/golangci-lint /usr/bin/golangci-lint
+COPY --from=builder /go/bin/govulncheck /usr/bin/govulncheck
 COPY --from=builder /go/bin/httperroryzer /usr/bin/httperroryzer
 COPY --from=builder /go/bin/structslop /usr/bin/structslop
 COPY --from=builder /go/bin/tomll /usr/bin/tomll


### PR DESCRIPTION
- add install steps for all standard image variants
- use current pseudoversion for pre-1.0 release in Dockerfiles and go.mod file
- add fake import in tools.go for golang.org/x/vuln/vulncheck

fixes GH-734