### PR TITLE
Adjust CI timeout when building all images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build all images using Makefile
     runs-on: ubuntu-latest
     # Default: 360 minutes
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Print Docker version


### PR DESCRIPTION
Increase timeout from 10 minutes to 20 minutes. While often under 10 minutes, build times have been spiking recently and as a result the `make build` CI job is being cancelled as a result.

fixes GH-752