### PR TITLE
Switch unstable image from Go 1.19.4 to 1.20rc1

### DIFF
--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.19.4 as builder
+FROM golang:1.20rc1 as builder
 
 ENV GOLANGCI_LINT_VERSION="v1.50.1"
 ENV STATICCHECK_VERSION="v0.3.3"
@@ -36,7 +36,7 @@ RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION}
 
 
-FROM golang:1.19.4 as final
+FROM golang:1.20rc1 as final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
fixes GH-786