### PR TITLE
Note golangci-lint versions per img type

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,16 @@ others.
 
 ## Linting tools included
 
-| Linter                                                                | Version                              |
-| --------------------------------------------------------------------- | ------------------------------------ |
-| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2022.1.3` (`v0.3.3`)                |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.50.1`                            |
-| [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `v0.0.0-20230109202529-975d4c73dae3` |
-| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`                             |
-| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.7`                             |
-| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.6`                             |
-| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`                             |
+| Linter                                                                | Version                                                                                                    |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2022.1.3` (`v0.3.3`)                                                                                      |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.50.1` for `stable` and `oldstable` images                                                              |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | [`feat/go1.20` dev branch](https://github.com/atc0005/golangci-lint/tree/feat/go1.20) for `unstable` image |
+| [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `v0.0.0-20230109202529-975d4c73dae3`                                                                       |
+| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`                                                                                                   |
+| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.7`                                                                                                   |
+| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.6`                                                                                                   |
+| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`                                                                                                   |
 
 ## Docker images
 


### PR DESCRIPTION
- v1.50.1 for stable, oldstable images
- feat/go1.20 dev branch for unstable image

refs GH-789