### PR TITLE
Install staticcheck from master for unstable image

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,15 @@ others.
 
 ## Linting tools included
 
-| Linter                                                                | Version                                                                                                    |
-| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2022.1.3` (`v0.3.3`)                                                                                      |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.50.1` for `stable` and `oldstable` images                                                              |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | [`feat/go1.20` dev branch](https://github.com/atc0005/golangci-lint/tree/feat/go1.20) for `unstable` image |
-| [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `v0.0.0-20230109202529-975d4c73dae3`                                                                       |
-| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`                                                                                                   |
-| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.7`                                                                                                   |
-| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.6`                                                                                                   |
-| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`                                                                                                   |
+| Linter                                                                | Version                                                                                                                                                                    |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2022.1.3` (`v0.3.3`) for `stable` and `oldstable`, [`master branch`](https://github.com/dominikh/go-tools/commit/58c4d7e4b720c21f21f0d68e60a31117995fcd0b) for `unstable` |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.50.1` for `stable` and `oldstable`, [`feat/go1.20` dev branch](https://github.com/atc0005/golangci-lint/tree/feat/go1.20) for `unstable` image                         |
+| [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `v0.0.0-20230109202529-975d4c73dae3`                                                                                                                                       |
+| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`                                                                                                                                                                   |
+| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.7`                                                                                                                                                                   |
+| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.0.6`                                                                                                                                                                   |
+| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.4.0`                                                                                                                                                                   |
 
 ## Docker images
 

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -9,8 +9,19 @@
 
 FROM golang:1.20rc2 as builder
 
+# A current dev branch build (mirrored to fork) is used for pre-release Go
+# versions, otherwise the latest upstream build of the tool is installed in
+# this image.
+#
+# See https://github.com/atc0005/go-ci/issues/789 for details.
 ENV GOLANGCI_LINT_VERSION="feat/go1.20"
-ENV STATICCHECK_VERSION="v0.3.3"
+
+# A current master branch build is used for pre-release Go versions, otherwise
+# the latest upstream build of the tool is installed in this image.
+#
+# See https://github.com/atc0005/go-ci/issues/812 for details.
+ENV STATICCHECK_VERSION="58c4d7e4b720c21f21f0d68e60a31117995fcd0b"
+
 ENV GOVULNCHECK_VERSION="v0.0.0-20230109202529-975d4c73dae3"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.7"
@@ -19,8 +30,9 @@ ENV ERRWRAP_VERSION="v1.4.0"
 
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
-    && staticcheck --version \
-    && echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
+    && staticcheck --version
+
+RUN echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
     && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
     && echo "Installing httperroryzer@${HTTPERRORYZER_VERSION}" \
     && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
@@ -53,8 +65,19 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
     golang:rc image or if not recently available, the latest stable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
-ENV GOLANGCI_LINT_VERSION="v1.50.1"
-ENV STATICCHECK_VERSION="v0.3.3"
+# A current dev branch build (mirrored to fork) is used for pre-release Go
+# versions, otherwise the latest upstream build of the tool is installed in
+# this image.
+#
+# See https://github.com/atc0005/go-ci/issues/789 for details.
+ENV GOLANGCI_LINT_VERSION="feat/go1.20"
+
+# A current master branch build is used for pre-release Go versions, otherwise
+# the latest upstream build of the tool is installed in this image.
+#
+# See https://github.com/atc0005/go-ci/issues/812 for details.
+ENV STATICCHECK_VERSION="58c4d7e4b720c21f21f0d68e60a31117995fcd0b"
+
 ENV GOVULNCHECK_VERSION="v0.0.0-20230109202529-975d4c73dae3"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV STRUCTSLOP_VERSION="v0.0.7"


### PR DESCRIPTION
- Use latest master branch commit for unstable image until Go 1.20 and new staticcheck versions are released
  - currently commit 58c4d7e4b720c21f21f0d68e60a31117995fcd0b
- update README to list dev/master branches for unstable image copies of staticheck and golangci-lint

fixes GH-812