### PR TITLE
Disable `Build all images using Makefile` CI job

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,25 +16,25 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  build_all_images_using_makefile:
-    name: Build all images using Makefile
-    runs-on: ubuntu-latest
-    # Default: 360 minutes
-    timeout-minutes: 20
-
-    steps:
-      - name: Print Docker version
-        run: docker --version
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-
-      # bsdmainutils provides "column" which is used by the Makefile
-      - name: Install Ubuntu packages
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
-
-      - name: Build images using project Makefile
-        run: make build
+  #   build_all_images_using_makefile:
+  #     name: Build all images using Makefile
+  #     runs-on: ubuntu-latest
+  #     # Default: 360 minutes
+  #     timeout-minutes: 20
+  #
+  #     steps:
+  #       - name: Print Docker version
+  #         run: docker --version
+  #
+  #       - name: Check out code into the Go module directory
+  #         uses: actions/checkout@v3
+  #
+  #       # bsdmainutils provides "column" which is used by the Makefile
+  #       - name: Install Ubuntu packages
+  #         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
+  #
+  #       - name: Build images using project Makefile
+  #         run: make build
 
   build_stable_image_using_makefile:
     name: Build stable image using Makefile


### PR DESCRIPTION
Currently running each image build task as separate CI jobs, so building all images via the "build everything" job doesn't add a whole lot of extra value.

I originally intended the `make build` job to catch any image build tasks I forgot to add individually, but provided I pay attention that risk is low and running this CI job just burns up CI build time that is better used for other work.

fixes GH-824