### PR TITLE
Update oldstable image to Go 1.19.5

### DIFF
--- a/oldstable/Dockerfile
+++ b/oldstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18.10
+FROM golang:1.19.5
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
Now that Go 1.20 is officially released it is considered the current stable version. The Go 1.19 series is now the "oldstable" version.

Go 1.18 is no longer supported by the Go team (nor tools such as staticcheck).

refs GH-831