### PR TITLE
Enable linters previously failing with generics

### DIFF
--- a/oldstable/.golangci.yml
+++ b/oldstable/.golangci.yml
@@ -47,14 +47,6 @@ linters:
     - stylecheck
     - unconvert
 
-  disable:
-    # Incompatible with Go 1.18 (GH-568, GH-681)
-    # https://github.com/golangci/golangci-lint/issues/2649
-    - rowserrcheck
-    - sqlclosecheck
-    - structcheck
-    - wastedassign
-
 #
 # Disable govet:fieldalignment, re-enable deprecated maligned linter until the
 # Go team offers more control over the types of checks provided by the
@@ -84,17 +76,3 @@ linters-settings:
       # See https://github.com/atc0005/go-ci/issues/302 for more information.
       #
       - fieldalignment
-
-      # Incompatible with Go 1.18 (GH-568)
-      # https://github.com/golangci/golangci-lint/issues/2649
-      - nilness
-      - unusedwrite
-
-  gocritic:
-    disable:
-      # Incompatible with Go 1.18 (GH-568)
-      # https://github.com/golangci/golangci-lint/issues/2649
-      - hugeParam
-      - rangeValCopy
-      - typeDefFirst
-      - paramTypeCombine

--- a/stable/.golangci.yml
+++ b/stable/.golangci.yml
@@ -47,14 +47,6 @@ linters:
     - stylecheck
     - unconvert
 
-  disable:
-    # Incompatible with Go 1.18 (GH-568, GH-681)
-    # https://github.com/golangci/golangci-lint/issues/2649
-    - rowserrcheck
-    - sqlclosecheck
-    - structcheck
-    - wastedassign
-
 #
 # Disable govet:fieldalignment, re-enable deprecated maligned linter until the
 # Go team offers more control over the types of checks provided by the
@@ -84,17 +76,3 @@ linters-settings:
       # See https://github.com/atc0005/go-ci/issues/302 for more information.
       #
       - fieldalignment
-
-      # Incompatible with Go 1.18 (GH-568)
-      # https://github.com/golangci/golangci-lint/issues/2649
-      - nilness
-      - unusedwrite
-
-  gocritic:
-    disable:
-      # Incompatible with Go 1.18 (GH-568)
-      # https://github.com/golangci/golangci-lint/issues/2649
-      - hugeParam
-      - rangeValCopy
-      - typeDefFirst
-      - paramTypeCombine

--- a/unstable/.golangci.yml
+++ b/unstable/.golangci.yml
@@ -59,14 +59,6 @@ linters:
     - stylecheck
     - unconvert
 
-  disable:
-    # Incompatible with Go 1.18 (GH-568, GH-681)
-    # https://github.com/golangci/golangci-lint/issues/2649
-    - rowserrcheck
-    - sqlclosecheck
-    - structcheck
-    - wastedassign
-
 #
 # Disable govet:fieldalignment, re-enable deprecated maligned linter until the
 # Go team offers more control over the types of checks provided by the
@@ -97,17 +89,3 @@ linters-settings:
       # See https://github.com/atc0005/go-ci/issues/302 for more information.
       #
       - fieldalignment
-
-      # Incompatible with Go 1.18 (GH-568)
-      # https://github.com/golangci/golangci-lint/issues/2649
-      - nilness
-      - unusedwrite
-
-  gocritic:
-    disable:
-      # Incompatible with Go 1.18 (GH-568)
-      # https://github.com/golangci/golangci-lint/issues/2649
-      - hugeParam
-      - rangeValCopy
-      - typeDefFirst
-      - paramTypeCombine


### PR DESCRIPTION
Remove all explicit disable entries for linters listed as incompatible with generics.

fixes GH-844