### PR TITLE
Update Go Dockerfile version thresholds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,10 +73,10 @@ updates:
       - dependency-name: "golang"
         versions:
           # Greater than or equal to stable container image series
-          - ">= 1.19"
+          - ">= 1.20"
 
           # Less than oldstable series
-          - "< 1.18"
+          - "< 1.19"
     assignees:
       - "atc0005"
     labels:
@@ -107,8 +107,8 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          - ">= 1.20"
-          - "< 1.19"
+          - ">= 1.21"
+          - "< 1.20"
 
   - package-ecosystem: docker
     directory: "/stable/combined"
@@ -130,8 +130,8 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          - ">= 1.20"
-          - "< 1.19"
+          - ">= 1.21"
+          - "< 1.20"
 
   - package-ecosystem: docker
     directory: "/stable/build/alpine-x64"
@@ -153,8 +153,8 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          - ">= 1.20"
-          - "< 1.19"
+          - ">= 1.21"
+          - "< 1.20"
 
   - package-ecosystem: docker
     directory: "/stable/build/alpine-x86"
@@ -176,8 +176,8 @@ updates:
     ignore:
       - dependency-name: "i386/golang"
         versions:
-          - ">= 1.20"
-          - "< 1.19"
+          - ">= 1.21"
+          - "< 1.20"
 
   - package-ecosystem: docker
     directory: "/stable/build/debian"
@@ -199,8 +199,8 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          - ">= 1.20"
-          - "< 1.19"
+          - ">= 1.21"
+          - "< 1.20"
 
   - package-ecosystem: docker
     directory: "/stable/build/mirror"
@@ -222,8 +222,8 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          - ">= 1.20"
-          - "< 1.19"
+          - ">= 1.21"
+          - "< 1.20"
 
   - package-ecosystem: docker
     directory: "/unstable"


### PR DESCRIPTION
Update Dockerfile thresholds so that Dependabot will offer the expected version updates whenever a new Go releae occurs for the 1.20 series (stable, unstable) or the 1.19 series (oldstable).

I missed this as part of the v0.7.9 release prep work.

refs GH-831