### PR TITLE
Update Go 1.20.0 images to 1.20.1

### DIFF
--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20-alpine3.16
+FROM golang:1.20.1-alpine3.16
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.20-alpine3.16
+FROM i386/golang:1.20.1-alpine3.16
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/debian/Dockerfile
+++ b/stable/build/debian/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20
+FROM golang:1.20.1
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/mirror/Dockerfile
+++ b/stable/build/mirror/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20
+FROM golang:1.20.1
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20
+FROM golang:1.20.1
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/linting/Dockerfile
+++ b/stable/linting/Dockerfile
@@ -12,7 +12,7 @@
 # builder image
 # use the same environment as our final image for binary compatibility
 # FROM golangci/golangci-lint:v1.45.0-alpine as builder
-FROM golang:1.20 as builder
+FROM golang:1.20.1 as builder
 
 ENV GOLANGCI_LINT_VERSION="v1.51.1"
 ENV STATICCHECK_VERSION="v0.4.1"
@@ -33,7 +33,7 @@ RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
 
 # For CI "linting only" use
 # FROM golangci/golangci-lint:v1.45.0-alpine
-FROM golang:1.20 as final
+FROM golang:1.20.1 as final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20 as builder
+FROM golang:1.20.1 as builder
 
 # A current dev branch build (mirrored to fork) is used for pre-release Go
 # versions, otherwise the latest upstream build of the tool is installed in
@@ -53,7 +53,7 @@ RUN echo "Installing golangci-lint@${GOLANGCI_LINT_VERSION}" \
     && golangci-lint --version
 
 
-FROM golang:1.20 as final
+FROM golang:1.20.1 as final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
When I last updated the stable & unstable Dockerfiles to use the latest Go 1.20 images I use the standard Go version convention of "1.20" instead of "1.20.0". The official Go Docker images use 1.20 as a sort of "floating" tag to reference the latest version from the 1.20 series and not explicitly 1.20.0.

This PR updates the Dockerfiles to explicitly reference the latest 1.20.1 version.

refs af1b7eff24278f8ebe8b41bce2861893042d96a1
refs https://github.com/dependabot/dependabot-core/issues/6672