### PR TITLE
Use local job defs for scheduled jobs

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,37 +16,6 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  #   build_all_images_using_makefile:
-  #     name: Build all images using Makefile
-  #     runs-on: ubuntu-latest
-  #     # Default: 360 minutes
-  #     timeout-minutes: 20
-  #
-  #     steps:
-  #       - name: Print Docker version
-  #         run: docker --version
-  #
-  #       - name: Check out code into the Go module directory
-  #         uses: actions/checkout@v3
-  #
-  #       # Mark the current working directory as a safe directory in git to
-  #       # resolve "dubious ownership" complaints.
-  #       #
-  #       # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-  #       # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
-  #       # https://github.com/actions/runner-images/issues/6775
-  #       # https://github.com/actions/checkout/issues/766
-  #       - name: Mark the current working directory as a safe directory in git
-  #         # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-  #         run: git config --global --add safe.directory "${PWD}"
-  #
-  #       # bsdmainutils provides "column" which is used by the Makefile
-  #       - name: Install Ubuntu packages
-  #         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
-  #
-  #       - name: Build images using project Makefile
-  #         run: make build
-
   build_stable_image_using_makefile:
     name: Build stable image using Makefile
     runs-on: ubuntu-latest

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -16,6 +16,33 @@ on:
     - cron: "30 4 1 * *"
 
 jobs:
-  lint:
-    name: Monthly Tasks
-    uses: atc0005/shared-project-resources/.github/workflows/scheduled-monthly.yml@master
+  build_all_images_using_makefile:
+    name: Build all images using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 20
+
+    steps:
+      - name: Print Docker version
+        run: docker --version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Build images using project Makefile
+        run: make build

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -17,5 +17,5 @@ on:
 
 jobs:
   lint:
-    name: Weekly Tasks
-    uses: atc0005/shared-project-resources/.github/workflows/scheduled-weekly.yml@master
+    name: Lint
+    uses: atc0005/shared-project-resources/.github/workflows/lint-project-files.yml@master


### PR DESCRIPTION
- re-enable `make build` as a monthly task to build all images
- remove imports for shared `scheduled-*.yml` workflow files and define local jobs to this repo
  - the jobs for this repo are different enough that pulling in a blanket "org-wide" set of tasks is unlikely to end well