### PR TITLE
Remove stray space in image title LABEL

### DIFF
--- a/stable/build/mirror/Dockerfile
+++ b/stable/build/mirror/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
 LABEL org.opencontainers.image.documentation="https://github.com/atc0005/go-ci"
 LABEL org.opencontainers.image.url="https://github.com/atc0005/go-ci"
-LABEL org.opencontainers.image.title="go-ci-stable-mirror-build "
+LABEL org.opencontainers.image.title="go-ci-stable-mirror-build"
 LABEL org.opencontainers.image.description="Docker image intended to mirror \
     current upstream stable golang image for Makefile-driven test, linting \
     and build tasks. Very few modifications are made to the original image."


### PR DESCRIPTION
This is for the `go-ci-stable-mirror-build` image Dockerfile.

It is likely ignored when compiling the image, but best to be sure and trim it now.