### PR TITLE
Rework mirror images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -203,7 +203,30 @@ updates:
           - "< 1.20"
 
   - package-ecosystem: docker
-    directory: "/stable/build/mirror"
+    directory: "/mirror/1.19"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "CI"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "docker"
+    ignore:
+      - dependency-name: "golang"
+        versions:
+          - ">= 1.20"
+          - "< 1.19"
+
+  - package-ecosystem: docker
+    directory: "/mirror/1.20"
     open-pull-requests-limit: 10
     target-branch: "master"
     schedule:

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,15 @@ DOCKER_IMAGE_REPO 					= go-ci
 GITHUB_PROJECT_REPO					= go-ci
 DOCKER_IMAGE_NAME_DEBIAN_BUILD		= go-ci-stable-debian-build
 DOCKER_IMAGE_NAME_MIRROR_BUILD		= go-ci-stable-mirror-build
+
+DOCKER_IMAGE_NAME_MIRROR_BUILD_GO114		= go-ci-stable-mirror-build-go1.14
+DOCKER_IMAGE_NAME_MIRROR_BUILD_GO115		= go-ci-stable-mirror-build-go1.15
+DOCKER_IMAGE_NAME_MIRROR_BUILD_GO116		= go-ci-stable-mirror-build-go1.16
+DOCKER_IMAGE_NAME_MIRROR_BUILD_GO117		= go-ci-stable-mirror-build-go1.17
+DOCKER_IMAGE_NAME_MIRROR_BUILD_GO118		= go-ci-stable-mirror-build-go1.18
+DOCKER_IMAGE_NAME_MIRROR_BUILD_GO119		= go-ci-stable-mirror-build-go1.19
+DOCKER_IMAGE_NAME_MIRROR_BUILD_GO120		= go-ci-stable-mirror-build-go1.20
+
 DOCKER_IMAGE_NAME_ALPINE_BUILDX86	= go-ci-stable-alpine-buildx86
 DOCKER_IMAGE_NAME_ALPINE_BUILDX64	= go-ci-stable-alpine-buildx64
 DOCKER_IMAGE_NAME_STABLE 			= go-ci-stable
@@ -53,7 +62,6 @@ DOCKER_FILES 						= oldstable/Dockerfile \
 										stable/build/alpine-x64/Dockerfile \
 										stable/build/alpine-x86/Dockerfile \
 										stable/build/debian/Dockerfile \
-										stable/build/mirror/Dockerfile \
 										stable/combined/Dockerfile \
 										stable/linting/Dockerfile \
 										unstable/Dockerfile \
@@ -178,23 +186,96 @@ stable-debian-build: pre-build
 		--label=$(DOCKER_IMAGE_CREATED_LABEL)
 	@echo "Completed build of stable-debian-build release"
 
-.PHONY: stable-mirror-build
-## stable-mirror-build: Build stable mirror image
-stable-mirror-build: pre-build
+.PHONY: legacy-mirror-build
+## legacy-mirror-build: Build legacy mirror images
+legacy-mirror-build: pre-build
 
-	@echo "Building stable-mirror-build release"
+	@echo "Building legacy-mirror-build images"
+
 	sudo docker image build \
 		--pull \
 		--no-cache \
-		stable/build/mirror/ \
-		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD) \
-		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD)-$(REPO_VERSION) \
-		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD) \
-		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD)-$(REPO_VERSION) \
+		mirror/1.14/ \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO114) \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO114)-$(REPO_VERSION) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO114) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO114)-$(REPO_VERSION) \
+		--label=$(DOCKER_IMAGE_OWNER_LABEL)
+
+	sudo docker image build \
+		--pull \
+		--no-cache \
+		mirror/1.15/ \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO115) \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO115)-$(REPO_VERSION) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO115) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO115)-$(REPO_VERSION) \
+		--label=$(DOCKER_IMAGE_OWNER_LABEL)
+
+	sudo docker image build \
+		--pull \
+		--no-cache \
+		mirror/1.16/ \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO116) \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO116)-$(REPO_VERSION) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO116) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO116)-$(REPO_VERSION) \
+		--label=$(DOCKER_IMAGE_OWNER_LABEL)
+	sudo docker image build \
+		--pull \
+		--no-cache \
+		mirror/1.17/ \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO117) \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO117)-$(REPO_VERSION) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO117) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO117)-$(REPO_VERSION) \
+		--label=$(DOCKER_IMAGE_OWNER_LABEL)
+
+	sudo docker image build \
+		--pull \
+		--no-cache \
+		mirror/1.18/ \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO118) \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO118)-$(REPO_VERSION) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO118) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO118)-$(REPO_VERSION) \
+		--label=$(DOCKER_IMAGE_OWNER_LABEL)
+
+	@sudo docker image ls --filter "label=$(DOCKER_IMAGE_OWNER_LABEL)"
+
+	@echo "Completed build of legacy-mirror-build images"
+
+.PHONY: stable-mirror-build
+## stable-mirror-build: Build stable mirror images
+stable-mirror-build: pre-build
+
+	@echo "Building stable-mirror-build images"
+
+	sudo docker image build \
+		--pull \
+		--no-cache \
+		mirror/1.19/ \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO119) \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO119)-$(REPO_VERSION) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO119) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO119)-$(REPO_VERSION) \
 		--label=$(DOCKER_IMAGE_OWNER_LABEL) \
 		--label=$(DOCKER_IMAGE_REVISION_LABEL) \
 		--label=$(DOCKER_IMAGE_CREATED_LABEL)
-	@echo "Completed build of stable-mirror-build release"
+
+	sudo docker image build \
+		--pull \
+		--no-cache \
+		mirror/1.20/ \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO120) \
+		-t $(DOCKER_IMAGE_REGISTRY)/$(DOCKER_IMAGE_REGISTRY_USER)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO120)-$(REPO_VERSION) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO120) \
+		-t $(GITHUB_IMAGE_REGISTRY)/$(GITHUB_IMAGE_REGISTRY_USER)/$(GITHUB_PROJECT_REPO):$(DOCKER_IMAGE_NAME_MIRROR_BUILD_GO120)-$(REPO_VERSION) \
+		--label=$(DOCKER_IMAGE_OWNER_LABEL) \
+		--label=$(DOCKER_IMAGE_REVISION_LABEL) \
+		--label=$(DOCKER_IMAGE_CREATED_LABEL)
+
+	@echo "Completed build of stable-mirror-build images"
 
 .PHONY: stable-linting-only
 ## stable-linting-only: Build stable linting-only image
@@ -269,7 +350,7 @@ pre-build:
 
 
 .PHONY: build
-## build: build all Docker container images
+## build: build all current Docker container images (legacy not included)
 build: pre-build build-stable build-stable-alpine-buildx64 build-stable-alpine-buildx86 stable-debian-build stable-mirror-build stable-linting-only build-oldstable build-unstable
 
 	@echo "Remove temporary copies of bundled files"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tooling for linting, testing and building Go applications
   - [`go-ci-stable-alpine-buildx86`](#go-ci-stable-alpine-buildx86)
   - [`go-ci-stable-alpine-buildx64`](#go-ci-stable-alpine-buildx64)
   - [`go-ci-stable-debian-build`](#go-ci-stable-debian-build)
-  - [`go-ci-stable-mirror-build`](#go-ci-stable-mirror-build)
+  - [`go-ci-stable-mirror-build-*`](#go-ci-stable-mirror-build-)
   - [`go-ci-oldstable`](#go-ci-oldstable)
   - [`go-ci-unstable`](#go-ci-unstable)
   - [`go-ci-lint-only`](#go-ci-lint-only)
@@ -110,14 +110,19 @@ wish for it to be maintained & available for use:
 
 - <https://github.com/atc0005/go-ci/issues/657>
 
-### `go-ci-stable-mirror-build`
+### `go-ci-stable-mirror-build-*`
 
-- built from the latest version of the current stable `golang` image.
-- intended to mirror current upstream stable `golang` image for
-  Makefile-driven testing, linting and build tasks.
+- built from the latest version of the `golang` image for that series
+  - e.g., the `go-ci-mirror-build-go1.14` image is built from the final
+    release version in the 1.14 series (1.14.15)
+- intended to mirror current upstream `golang` image for Makefile-driven
+  testing, linting and build tasks.
 - few (if any) customizations are intended for this image, instead relying on
   a project's Makefile or other build tool to setup the environment for tasks
   such as testing, linting & building source code
+
+These images are intended to assist with asserting that projects build with
+the latest version in a specific series.
 
 ### `go-ci-oldstable`
 

--- a/mirror/1.14/Dockerfile
+++ b/mirror/1.14/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-ci
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://hub.docker.com/_/golang
+
+FROM golang:1.14.15
+
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
+
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+LABEL org.opencontainers.image.documentation="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.url="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.title="go-ci-mirror-build-go1.14"
+LABEL org.opencontainers.image.description="Docker image intended to mirror \
+    latest upstream golang image for the Go 1.14 series. Used by \
+    Makefile-driven test, linting and build tasks."
+LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"

--- a/mirror/1.15/Dockerfile
+++ b/mirror/1.15/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20.1
+FROM golang:1.15.15
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -15,8 +15,8 @@ LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
 LABEL org.opencontainers.image.documentation="https://github.com/atc0005/go-ci"
 LABEL org.opencontainers.image.url="https://github.com/atc0005/go-ci"
-LABEL org.opencontainers.image.title="go-ci-stable-mirror-build"
+LABEL org.opencontainers.image.title="go-ci-mirror-build-go1.15"
 LABEL org.opencontainers.image.description="Docker image intended to mirror \
-    current upstream stable golang image for Makefile-driven test, linting \
-    and build tasks. Very few modifications are made to the original image."
+    latest upstream golang image for the Go 1.15 series. Used by \
+    Makefile-driven test, linting and build tasks."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"

--- a/mirror/1.16/Dockerfile
+++ b/mirror/1.16/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-ci
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://hub.docker.com/_/golang
+
+FROM golang:1.16.15
+
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
+
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+LABEL org.opencontainers.image.documentation="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.url="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.title="go-ci-mirror-build-go1.16"
+LABEL org.opencontainers.image.description="Docker image intended to mirror \
+    latest upstream golang image for the Go 1.16 series. Used by \
+    Makefile-driven test, linting and build tasks."
+LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"

--- a/mirror/1.17/Dockerfile
+++ b/mirror/1.17/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-ci
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://hub.docker.com/_/golang
+
+FROM golang:1.17.13
+
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
+
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+LABEL org.opencontainers.image.documentation="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.url="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.title="go-ci-mirror-build-go1.17"
+LABEL org.opencontainers.image.description="Docker image intended to mirror \
+    latest upstream golang image for the Go 1.17 series. Used by \
+    Makefile-driven test, linting and build tasks."
+LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"

--- a/mirror/1.18/Dockerfile
+++ b/mirror/1.18/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-ci
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://hub.docker.com/_/golang
+
+FROM golang:1.18.10
+
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
+
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+LABEL org.opencontainers.image.documentation="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.url="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.title="go-ci-mirror-build-go1.18"
+LABEL org.opencontainers.image.description="Docker image intended to mirror \
+    latest upstream golang image for the Go 1.18 series. Used by \
+    Makefile-driven test, linting and build tasks."
+LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"

--- a/mirror/1.19/Dockerfile
+++ b/mirror/1.19/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-ci
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://hub.docker.com/_/golang
+
+FROM golang:1.19.6
+
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
+
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+LABEL org.opencontainers.image.documentation="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.url="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.title="go-ci-mirror-build-go1.19"
+LABEL org.opencontainers.image.description="Docker image intended to mirror \
+    latest upstream golang image for the Go 1.19 series. Used by \
+    Makefile-driven test, linting and build tasks."
+LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"

--- a/mirror/1.20/Dockerfile
+++ b/mirror/1.20/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/go-ci
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://hub.docker.com/_/golang
+
+FROM golang:1.20.1
+
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
+
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+LABEL org.opencontainers.image.documentation="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.url="https://github.com/atc0005/go-ci"
+LABEL org.opencontainers.image.title="go-ci-mirror-build-go1.20"
+LABEL org.opencontainers.image.description="Docker image intended to mirror \
+    latest upstream golang image for the Go 1.20 series. Used by \
+    Makefile-driven test, linting and build tasks."
+LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"


### PR DESCRIPTION
- add Go 1.14 "legacy" mirror image
- add Go 1.15 "legacy" mirror image
- add Go 1.16 "legacy" mirror image
- add Go 1.17 "legacy" mirror image
- add Go 1.18 "legacy" mirror image
- add Go 1.19 mirror image
- add Go 1.20 mirror image
  - move the stable/build/mirror image Dockerfile and placed alongside other series-specific image files
- update README to note mirror image changes (light edits)
- update Dependabot configuration to monitor updates for the last two release series
  - at present this is the 1.19 and 1.20 series
  - no real benefit to monitoring retired/legacy series as they're unlikely to receive base image updates
- update Makefile to create new legacy-mirror-build recipe to handle building unsupported Go version images
  - this recipe is *not* called when running the `build` recipe
  - this recipe explicitly does *not* add labels known to generate unique image ID values in an effort to provide reproducible image generation
  - this recipe *does* add repo tag/version details as an additional tag for reference purposes from dependent projects

refs GH-847