### PR TITLE
Update CI jobs to build legacy images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -140,8 +140,8 @@ jobs:
       - name: Build stable Debian image
         run: make stable-debian-build
 
-  build_stable_mirror_image_using_makefile:
-    name: Build stable mirror image using Makefile
+  build_stable_mirror_images_using_makefile:
+    name: Build stable mirror images using Makefile
     runs-on: ubuntu-latest
     # Default: 360 minutes
     timeout-minutes: 10

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -44,5 +44,8 @@ jobs:
       - name: Install Ubuntu packages
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make gcc bsdmainutils
 
-      - name: Build images using project Makefile
+      - name: Build non-legacy images using project Makefile
         run: make build
+
+      - name: Build legacy images using project Makefile
+        run: make legacy-mirror-build


### PR DESCRIPTION
- tweak naming of the stable mirror image build task to reflect that this job now builds multiple mirror images
- add legacy images build job to the monthly scheduled jobs workflow
  - just to make sure that the Makefile recipe continues to function as expected

refs GH-847