### PR TITLE
Update tools/go.mod monitoring config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
 
     allow:
       # Allow both direct and indirect updates for all packages
-      - dependency-type: "all"
+      - dependency-type: "direct"
 
     commit-message:
       # Prefix all commit messages with "go.mod"


### PR DESCRIPTION
Switch from `all` dependency type to `direct`.

The intent is to opt-out of indirect dependency PRs while still receiving PRs for direct dependencies.