### PR TITLE
Add nishanths/predeclared linter

### DIFF
--- a/unstable/combined/.golangci.yml
+++ b/unstable/combined/.golangci.yml
@@ -55,6 +55,7 @@ linters:
     - misspell
     - nilnil
     - prealloc
+    - predeclared
     - revive
     - staticcheck
     - stylecheck


### PR DESCRIPTION
Enable for unstable image.

fixes GH-642