### PR TITLE
Disable depguard linter

### DIFF
--- a/oldstable/combined/.golangci.yml
+++ b/oldstable/combined/.golangci.yml
@@ -25,7 +25,8 @@ issues:
 # Reminder: Sort this after every change
 linters:
   enable:
-    - depguard
+    # https://github.com/atc0005/go-ci/issues/1024
+    # - depguard
     - dogsled
     - dupl
     - exportloopref

--- a/stable/combined/.golangci.yml
+++ b/stable/combined/.golangci.yml
@@ -25,7 +25,8 @@ issues:
 # Reminder: Sort this after every change
 linters:
   enable:
-    - depguard
+    # https://github.com/atc0005/go-ci/issues/1024
+    # - depguard
     - dogsled
     - dupl
     - exportloopref

--- a/unstable/combined/.golangci.yml
+++ b/unstable/combined/.golangci.yml
@@ -32,7 +32,8 @@ issues:
 # Reminder: Sort this after every change
 linters:
   enable:
-    - depguard
+    # https://github.com/atc0005/go-ci/issues/1024
+    # - depguard
     - dogsled
     - dupl
     - exportloopref


### PR DESCRIPTION
By having v2 of the linter enabled without an explicitly defined configuration the linter assumes that *no* non-stdlib packages are permitted.

We disable the linter because we do not have any need to define "global" permit/deny lists for any projects using images from this project.

fixes GH-1024