### PR TITLE
Update Alpine build image release series to 3.18

### DIFF
--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -23,17 +23,17 @@ LABEL org.opencontainers.image.description="Docker container image used to build
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
 # NOTE: This version was different than the base `gcc` pkg when last checked
-ENV APK_GCC_MINGW64_VERSION="11.3.0-r0"
+ENV APK_GCC_MINGW64_VERSION="12.2.0-r3"
 
-ENV APK_BASH_VERSION="5.1.16-r2"
-ENV APK_GCC_VERSION="11.2.1_git20220219-r2"
-ENV APK_GIT_VERSION="2.36.6-r0"
-ENV APK_MAKE_VERSION="4.3-r0"
-ENV APK_UTIL_LINUX_VERSION="2.38-r1"
-ENV APK_FILE_VERSION="5.41-r0"
-ENV APK_NANO_VERSION="6.3-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.3-r3"
-ENV APK_XZ_VERSION="5.2.5-r1"
+ENV APK_BASH_VERSION="5.2.15-r5"
+ENV APK_GCC_VERSION="12.2.1_git20220924-r10"
+ENV APK_GIT_VERSION="2.40.1-r0"
+ENV APK_MAKE_VERSION="4.4.1-r1"
+ENV APK_UTIL_LINUX_VERSION="2.38.1-r8"
+ENV APK_FILE_VERSION="5.44-r3"
+ENV APK_NANO_VERSION="7.2-r1"
+ENV APK_MUSL_DEV_VERSION="1.2.4-r0"
+ENV APK_XZ_VERSION="5.4.3-r0"
 
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.1"

--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20.4-alpine3.16
+FROM golang:1.20.4-alpine3.18
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -22,17 +22,17 @@ LABEL org.opencontainers.image.description="Docker container image used to build
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
 # NOTE: This version was different than the base `gcc` pkg when last checked
-ENV APK_GCC_MINGW64_VERSION="11.3.0-r0"
+ENV APK_GCC_MINGW64_VERSION="12.2.0-r3"
 
-ENV APK_BASH_VERSION="5.1.16-r2"
-ENV APK_GCC_VERSION="11.2.1_git20220219-r2"
-ENV APK_GIT_VERSION="2.36.6-r0"
-ENV APK_MAKE_VERSION="4.3-r0"
-ENV APK_UTIL_LINUX_VERSION="2.38-r1"
-ENV APK_FILE_VERSION="5.41-r0"
-ENV APK_NANO_VERSION="6.3-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.3-r3"
-ENV APK_XZ_VERSION="5.2.5-r1"
+ENV APK_BASH_VERSION="5.2.15-r5"
+ENV APK_GCC_VERSION="12.2.1_git20220924-r10"
+ENV APK_GIT_VERSION="2.40.1-r0"
+ENV APK_MAKE_VERSION="4.4.1-r1"
+ENV APK_UTIL_LINUX_VERSION="2.38.1-r8"
+ENV APK_FILE_VERSION="5.44-r3"
+ENV APK_NANO_VERSION="7.2-r1"
+ENV APK_MUSL_DEV_VERSION="1.2.4-r0"
+ENV APK_XZ_VERSION="5.4.3-r0"
 
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.1"

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.20.4-alpine3.16
+FROM i386/golang:1.20.4-alpine3.18
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
## Changes

- switch from Alpine 3.16 to Alpine 3.18
- update Alpine build image dependencies

## References

- fixes GH-1043