### PR TITLE
Update `unstable` images to Go 1.21rc2

### DIFF
--- a/unstable/build/release/Dockerfile
+++ b/unstable/build/release/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20.5
+FROM golang:1.21rc2-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20.5 as builder
+FROM golang:1.21rc2-bookworm as builder
 
 # A current dev branch build (mirrored to fork) is used for pre-release Go
 # versions, otherwise the latest upstream build of the tool is installed in
@@ -56,7 +56,7 @@ RUN echo "Installing golangci-lint@${GOLANGCI_LINT_VERSION}" \
     && golangci-lint --version
 
 
-FROM golang:1.20.5 as final
+FROM golang:1.21rc2-bookworm as final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
- switch from current stable Go 1.20 to 1.21rc2
- explicitly specify base image OS

fixes GH-1058