### PR TITLE
Update Dockerfiles to specify chosen base image OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,3 +326,4 @@ official release is also provided for further review.
   - <https://fabianlee.org/2020/01/26/golang-using-multi-stage-builds-to-create-clean-docker-images/>
   - <https://hub.docker.com/r/golangci/golangci-lint>
   - <https://hub.docker.com/_/golang>
+  - <https://www.debian.org/releases/>

--- a/mirror/1.14/Dockerfile
+++ b/mirror/1.14/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.14.15
+FROM golang:1.14.15-buster
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/mirror/1.15/Dockerfile
+++ b/mirror/1.15/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.15.15
+FROM golang:1.15.15-buster
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/mirror/1.16/Dockerfile
+++ b/mirror/1.16/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.16.15
+FROM golang:1.16.15-bullseye
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/mirror/1.17/Dockerfile
+++ b/mirror/1.17/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.17.13
+FROM golang:1.17.13-bullseye
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/mirror/1.18/Dockerfile
+++ b/mirror/1.18/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.18.10
+FROM golang:1.18.10-bullseye
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/mirror/1.19/Dockerfile
+++ b/mirror/1.19/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.19.10
+FROM golang:1.19.10-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/mirror/1.20/Dockerfile
+++ b/mirror/1.20/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20.5
+FROM golang:1.20.5-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/oldstable/build/release/Dockerfile
+++ b/oldstable/build/release/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.19.10
+FROM golang:1.19.10-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/oldstable/combined/Dockerfile
+++ b/oldstable/combined/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.19.10
+FROM golang:1.19.10-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/cgo-mingw-w64/Dockerfile
+++ b/stable/build/cgo-mingw-w64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20.5
+FROM golang:1.20.5-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/release/Dockerfile
+++ b/stable/build/release/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20.5
+FROM golang:1.20.5-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20.5
+FROM golang:1.20.5-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
## Changes

These images were updated to use the most recent stable base image OS available:

- mirror images
- oldstable images
- stable images

The bump to Go 1.21rc2 for the unstable images also included the change to specify the base image OS.

## Note regarding base image changes

Going forward the base image OS will likely stay the same for the life of the specific series reflected in the image type.

For example, Debian "bookworm" was recently released. When Go 1.21.0 is released as the next stable version, the "stable" Debian-based images will continue to use the "bookworm" OS as the base image for the life of the Go 1.21 series. If a newer Debian OS version is available when Go 1.22.0 is released then the "stable" images will adopt that Debian OS as the base image OS for Debian-based images. The 1.21 series will continue to use the former Debian OS as the base image OS (for Debian-based images).

## References

- fixes GH-1057
- refs GH-1058