### PR TITLE
Fix Go series used for Alpine oldstable images

### DIFF
--- a/oldstable/build/alpine-x64/Dockerfile
+++ b/oldstable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.20.4-alpine3.18
+FROM golang:1.19.10-alpine3.18
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/oldstable/build/alpine-x86/Dockerfile
+++ b/oldstable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.20.4-alpine3.18
+FROM i386/golang:1.19.10-alpine3.18
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
Switch from Go 1.20.x (1.20.4) to 1.19.x (1.19.10) as intended.

I intentionally set the version one back to 1.19.10 instead of 1.19.11 to make sure that Dependabot is configured to properly update these images to the intended release series.