### PR TITLE
Update timeout for release build workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -23,7 +23,7 @@ jobs:
 
     runs-on: ubuntu-latest
     # Default: 360 minutes
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Log tag info


### PR DESCRIPTION
Increase timeout from 30 to 45 minutes. The most recent build time was around 20 minutes (not counting uploads).

We may need to increase this further if this proves insufficient.