### PR TITLE
Increase timeout for monthly workflow

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build all images using Makefile
     runs-on: ubuntu-latest
     # Default: 360 minutes
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     steps:
       - name: Print Docker version


### PR DESCRIPTION
Increase from 20 minutes to 45 minutes to match the value used for the release build workflow.