### PR TITLE
Downgrade golangci-lint from v1.54.2 to v1.54.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following linting tools are included in the `go-ci-stable`,
 | Linter                                                                | Version               |
 | --------------------------------------------------------------------- | --------------------- |
 | [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2023.1.5` (`v0.4.5`) |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.54.2`             |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.54.1`             |
 | [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `v1.0.1`              |
 | [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`              |
 | [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.8`              |

--- a/oldstable/combined/Dockerfile
+++ b/oldstable/combined/Dockerfile
@@ -20,7 +20,7 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
     Based on the latest version of the current outgoing stable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
-ENV GOLANGCI_LINT_VERSION="v1.54.2"
+ENV GOLANGCI_LINT_VERSION="v1.54.1"
 ENV STATICCHECK_VERSION="v0.4.5"
 ENV GOVULNCHECK_VERSION="v1.0.1"
 ENV HTTPERRORYZER_VERSION="v0.0.1"

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -20,7 +20,7 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
     Based on the latest version of the current stable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
-ENV GOLANGCI_LINT_VERSION="v1.54.2"
+ENV GOLANGCI_LINT_VERSION="v1.54.1"
 ENV STATICCHECK_VERSION="v0.4.5"
 ENV GOVULNCHECK_VERSION="v1.0.1"
 ENV HTTPERRORYZER_VERSION="v0.0.1"

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -12,7 +12,7 @@ FROM golang:1.21-bookworm as builder
 # A current dev branch build (mirrored to fork) is used for pre-release Go
 # versions, otherwise the latest upstream build of the tool is installed in
 # this image.
-ENV GOLANGCI_LINT_VERSION="v1.54.2"
+ENV GOLANGCI_LINT_VERSION="v1.54.1"
 
 # A current master branch build is used for pre-release Go versions, otherwise
 # the latest upstream build of the tool is installed in this image.
@@ -73,7 +73,7 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 # A current dev branch build (mirrored to fork) is used for pre-release Go
 # versions, otherwise the latest upstream build of the tool is installed in
 # this image.
-ENV GOLANGCI_LINT_VERSION="v1.54.2"
+ENV GOLANGCI_LINT_VERSION="v1.54.1"
 
 # A current master branch build is used for pre-release Go versions, otherwise
 # the latest upstream build of the tool is installed in this image.


### PR DESCRIPTION
Multiple false-positive detections from gosec linter for G101 rule violation: "G101: Potential hardcoded credentials (gosec)"

See also:

- https://github.com/securego/gosec/issues/1001
- https://github.com/golangci/golangci-lint/issues/4037