### PR TITLE
Update unstable images version

### DIFF
--- a/unstable/build/alpine-x64/Dockerfile
+++ b/unstable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.21-alpine3.18
+FROM golang:1.21.0-alpine3.18
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/alpine-x86/Dockerfile
+++ b/unstable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.21-alpine3.18
+FROM i386/golang:1.21.0-alpine3.18
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/release/Dockerfile
+++ b/unstable/build/release/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.21-bookworm
+FROM golang:1.21.0-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.21-bookworm as builder
+FROM golang:1.21.0-bookworm as builder
 
 # A current dev branch build (mirrored to fork) is used for pre-release Go
 # versions, otherwise the latest upstream build of the tool is installed in


### PR DESCRIPTION
Switch from 1.21.x series to specific 1.21.0 release version.

Dependabot *should* see this change and offer the 1.21.1 update for each unstable image Dockerfile.