### PR TITLE
Fix Go 1.20 mirror image version constraint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -362,8 +362,8 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          - ">= 1.22"
-          - "< 1.21"
+          - ">= 1.21"
+          - "< 1.20"
 
   - package-ecosystem: docker
     directory: "/unstable/build/release"


### PR DESCRIPTION
Block updates from 1.19 and 1.21 series, restricting to just the 1.20 series as intended.

See also:

- GH-1178