### PR TITLE
Explicitly set `GOTOOLCHAIN` environment variable

### DIFF
--- a/mirror/1.19/Dockerfile
+++ b/mirror/1.19/Dockerfile
@@ -20,3 +20,9 @@ LABEL org.opencontainers.image.description="Docker image intended to mirror \
     latest upstream golang image for the Go 1.19 series. Used by \
     Makefile-driven test, linting and build tasks."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
+
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"

--- a/mirror/1.20/Dockerfile
+++ b/mirror/1.20/Dockerfile
@@ -20,3 +20,9 @@ LABEL org.opencontainers.image.description="Docker image intended to mirror \
     latest upstream golang image for the Go 1.20 series. Used by \
     Makefile-driven test, linting and build tasks."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
+
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"

--- a/mirror/1.21/Dockerfile
+++ b/mirror/1.21/Dockerfile
@@ -20,3 +20,9 @@ LABEL org.opencontainers.image.description="Docker image intended to mirror \
     latest upstream golang image for the Go 1.21 series. Used by \
     Makefile-driven test, linting and build tasks."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
+
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"

--- a/oldstable/build/alpine-x64/Dockerfile
+++ b/oldstable/build/alpine-x64/Dockerfile
@@ -22,6 +22,12 @@ LABEL org.opencontainers.image.description="Docker container image used to build
     Linux."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 # NOTE: This version was different than the base `gcc` pkg when last checked
 ENV APK_GCC_MINGW64_VERSION="12.2.0-r3"
 

--- a/oldstable/build/alpine-x86/Dockerfile
+++ b/oldstable/build/alpine-x86/Dockerfile
@@ -21,6 +21,12 @@ LABEL org.opencontainers.image.description="Docker container image used to build
     image. Supports cross-platform, static cgo-enabled builds for Windows and Linux."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 # NOTE: This version was different than the base `gcc` pkg when last checked
 ENV APK_GCC_MINGW64_VERSION="12.2.0-r3"
 

--- a/oldstable/build/release/Dockerfile
+++ b/oldstable/build/release/Dockerfile
@@ -20,6 +20,12 @@ LABEL org.opencontainers.image.description="Docker container image used to build
     releases of Go code. Based on the latest version of the upstream oldstable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
 ENV XZ_UTILS_VERSION="5.4.1-0.2"

--- a/oldstable/combined/Dockerfile
+++ b/oldstable/combined/Dockerfile
@@ -20,6 +20,12 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
     Based on the latest version of the current outgoing stable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 ENV GOLANGCI_LINT_VERSION="v1.55.1"
 ENV STATICCHECK_VERSION="v0.4.6"
 ENV GOVULNCHECK_VERSION="v1.0.1"

--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -22,6 +22,12 @@ LABEL org.opencontainers.image.description="Docker container image used to build
     Linux."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 # NOTE: This version was different than the base `gcc` pkg when last checked
 ENV APK_GCC_MINGW64_VERSION="12.2.0-r3"
 

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -21,6 +21,12 @@ LABEL org.opencontainers.image.description="Docker container image used to build
     image. Supports cross-platform, static cgo-enabled builds for Windows and Linux."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 # NOTE: This version was different than the base `gcc` pkg when last checked
 ENV APK_GCC_MINGW64_VERSION="12.2.0-r3"
 

--- a/stable/build/cgo-mingw-w64/Dockerfile
+++ b/stable/build/cgo-mingw-w64/Dockerfile
@@ -21,6 +21,12 @@ LABEL org.opencontainers.image.description="Docker container image used to build
     Supports static, cgo-enabled builds via mingw."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
 ENV APT_GCC_MULTILIB_VERSION="4:12.2.0-3"

--- a/stable/build/release/Dockerfile
+++ b/stable/build/release/Dockerfile
@@ -20,6 +20,12 @@ LABEL org.opencontainers.image.description="Docker container image used to build
     releases of Go code. Based on the latest version of the upstream stable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
 ENV XZ_UTILS_VERSION="5.4.1-0.2"

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -20,6 +20,12 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
     Based on the latest version of the current stable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 ENV GOLANGCI_LINT_VERSION="v1.55.1"
 ENV STATICCHECK_VERSION="v0.4.6"
 ENV GOVULNCHECK_VERSION="v1.0.1"

--- a/unstable/build/alpine-x64/Dockerfile
+++ b/unstable/build/alpine-x64/Dockerfile
@@ -22,6 +22,12 @@ LABEL org.opencontainers.image.description="Docker container image used to build
     Windows and Linux."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 # NOTE: This version was different than the base `gcc` pkg when last checked
 ENV APK_GCC_MINGW64_VERSION="12.2.0-r3"
 

--- a/unstable/build/alpine-x86/Dockerfile
+++ b/unstable/build/alpine-x86/Dockerfile
@@ -22,6 +22,12 @@ LABEL org.opencontainers.image.description="Docker container image used to build
     Windows and Linux."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 # NOTE: This version was different than the base `gcc` pkg when last checked
 ENV APK_GCC_MINGW64_VERSION="12.2.0-r3"
 

--- a/unstable/build/release/Dockerfile
+++ b/unstable/build/release/Dockerfile
@@ -21,6 +21,12 @@ LABEL org.opencontainers.image.description="Docker container image used to build
     golang:rc image or if not recently available, the latest stable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
 ENV XZ_UTILS_VERSION="5.4.1-0.2"

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -9,6 +9,12 @@
 
 FROM golang:1.21.0-bookworm as builder
 
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
 # A current dev branch build (mirrored to fork) is used for pre-release Go
 # versions, otherwise the latest upstream build of the tool is installed in
 # this image.
@@ -69,6 +75,12 @@ LABEL org.opencontainers.image.description="Docker container image used to lint,
     Based on the latest available non-stable golang:beta image, \
     golang:rc image or if not recently available, the latest stable golang image."
 LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
+
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
 
 # A current dev branch build (mirrored to fork) is used for pre-release Go
 # versions, otherwise the latest upstream build of the tool is installed in


### PR DESCRIPTION
Set variable to `local` to disable automatic fetching of Go toolchains newer than the version explicitly provided by each container image.

fixes GH-1188