### PR TITLE
Switch orijtech linters install source

### DIFF
--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -25,28 +25,63 @@ ENV GOLANGCI_LINT_VERSION="v1.55.2"
 ENV STATICCHECK_VERSION="v0.4.6"
 
 ENV GOVULNCHECK_VERSION="v1.0.3"
-ENV HTTPERRORYZER_VERSION="v0.0.1"
-ENV STRUCTSLOP_VERSION="v0.0.8"
-ENV TICKERYZER_VERSION="v0.0.3"
+# ENV HTTPERRORYZER_VERSION="v0.0.1"
+# ENV STRUCTSLOP_VERSION="v0.0.8"
+# ENV TICKERYZER_VERSION="v0.0.3"
 ENV TOMLL_VERSION="v2.1.1"
 ENV ERRWRAP_VERSION="v1.5.0"
+
+# These commits/versions are provided by temporary forks of the upstream
+# projects. The plan is to switch back to current upstream vesions once
+# the required dependencies are updated for those upstream projects.
+ENV HTTPERRORYZER_VERSION="daff15ed7aa6321f4c278dedfa087c23aef2399b"
+ENV STRUCTSLOP_VERSION="a152317819bb2aac2f36fbc46e92f34d4abcafc6"
+ENV TICKERYZER_VERSION="ea43e9b9956c5a0bea094b694b248de37810634a"
 
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
     && staticcheck --version
 
+# RUN echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
+#     && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
+#     && echo "Installing httperroryzer@${HTTPERRORYZER_VERSION}" \
+#     && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+#     && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
+#     && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
+#     && echo "Installing tickeryzer@${TICKERYZER_VERSION}" \
+#     && go install github.com/orijtech/tickeryzer/cmd/tickeryzer@${TICKERYZER_VERSION} \
+#     && echo "Installing tomll@${TOMLL_VERSION}" \
+#     && go install github.com/pelletier/go-toml/v2/cmd/tomll@${TOMLL_VERSION} \
+#     && echo "Installing errwrap@${ERRWRAP_VERSION}" \
+#     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION}
+
 RUN echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
     && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
-    && echo "Installing httperroryzer@${HTTPERRORYZER_VERSION}" \
-    && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
-    && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
-    && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
-    && echo "Installing tickeryzer@${TICKERYZER_VERSION}" \
-    && go install github.com/orijtech/tickeryzer/cmd/tickeryzer@${TICKERYZER_VERSION} \
     && echo "Installing tomll@${TOMLL_VERSION}" \
     && go install github.com/pelletier/go-toml/v2/cmd/tomll@${TOMLL_VERSION} \
     && echo "Installing errwrap@${ERRWRAP_VERSION}" \
     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION}
+
+RUN echo "Installing httperroryzer from temporary fork" \
+    && git clone https://github.com/atc0005/httperroryzer \
+    && cd httperroryzer \
+    && git checkout ${HTTPERRORYZER_VERSION} \
+    && go install ./cmd/httperroryzer \
+    && cd ..
+
+RUN echo "Installing structslop from temporary fork" \
+    && git clone https://github.com/atc0005/structslop \
+    && cd structslop \
+    && git checkout ${STRUCTSLOP_VERSION} \
+    && go install ./cmd/structslop \
+    && cd ..
+
+RUN echo "Installing tickeryzer from temporary fork" \
+    && git clone https://github.com/atc0005/tickeryzer \
+    && cd tickeryzer \
+    && git checkout ${TICKERYZER_VERSION} \
+    && go install ./cmd/tickeryzer \
+    && cd ..
 
 # RUN echo "Installing golangci-lint from dev feat/go1.20 branch" \
 #     && git clone https://github.com/atc0005/golangci-lint \


### PR DESCRIPTION
## Changes

Switch from upstream projects to temporary forks until the dependencies for those upstream projects are updated to work with newer Go versions.

## References

- fixes GH-1325
- fixes GH-1326
- fixes GH-1327