### PR TITLE
Fix unstable images Go release version

### DIFF
--- a/unstable/build/alpine-x64/Dockerfile
+++ b/unstable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.22-alpine3.18
+FROM golang:1.22.0-alpine3.18
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/alpine-x86/Dockerfile
+++ b/unstable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.22-alpine3.18
+FROM i386/golang:1.22.0-alpine3.18
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/release/Dockerfile
+++ b/unstable/build/release/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.22-bookworm
+FROM golang:1.22.0-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM golang:1.22-bookworm as builder
+FROM golang:1.22.0-bookworm as builder
 
 # Explicitly disable automatic fetching of Go toolchains newer than the
 # version explicitly provided by this container image.
@@ -103,7 +103,7 @@ RUN echo "Installing golangci-lint@${GOLANGCI_LINT_VERSION}" \
     && golangci-lint --version
 
 
-FROM golang:1.22-bookworm as final
+FROM golang:1.22.0-bookworm as final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
## Changes

Switch from 1.22 (series) to 1.22.0 (specific release version).

This restores the previous behavior of using specific upstream image releases instead of whatever happens to be available at the time these images are built.

## References

- fixes GH-1345