### PR TITLE
Fix Dependabot Docker image constraints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,7 +70,7 @@ updates:
     # Ignore updates from series associated with "stable" container image and
     # no longer supported Go versions.
     ignore:
-      - dependency-name: "golang"
+      - dependency-name: "amd64/golang"
         versions:
           # Greater than or equal to stable container image series
           - ">= 1.21"
@@ -99,7 +99,7 @@ updates:
     # Ignore updates from series associated with "stable" container image and
     # no longer supported Go versions.
     ignore:
-      - dependency-name: "golang"
+      - dependency-name: "amd64/golang"
         versions:
           # Greater than or equal to stable container image series
           - ">= 1.21"
@@ -134,7 +134,7 @@ updates:
     commit-message:
       prefix: "docker"
     ignore:
-      - dependency-name: "golang"
+      - dependency-name: "amd64/golang"
         versions:
           # Greater than or equal to stable container image series
           - ">= 1.21"
@@ -186,7 +186,7 @@ updates:
     commit-message:
       prefix: "docker"
     ignore:
-      - dependency-name: "golang"
+      - dependency-name: "amd64/golang"
         versions:
           - ">= 1.22"
           - "< 1.21"
@@ -209,7 +209,7 @@ updates:
     commit-message:
       prefix: "docker"
     ignore:
-      - dependency-name: "golang"
+      - dependency-name: "amd64/golang"
         versions:
           - ">= 1.22"
           - "< 1.21"
@@ -291,7 +291,7 @@ updates:
     commit-message:
       prefix: "docker"
     ignore:
-      - dependency-name: "golang"
+      - dependency-name: "amd64/golang"
         versions:
           - ">= 1.22"
           - "< 1.21"
@@ -314,7 +314,7 @@ updates:
     commit-message:
       prefix: "docker"
     ignore:
-      - dependency-name: "golang"
+      - dependency-name: "amd64/golang"
         versions:
           - ">= 1.22"
           - "< 1.21"
@@ -337,7 +337,7 @@ updates:
     commit-message:
       prefix: "docker"
     ignore:
-      - dependency-name: "golang"
+      - dependency-name: "amd64/golang"
         versions:
           - ">= 1.20"
           - "< 1.19"
@@ -360,7 +360,7 @@ updates:
     commit-message:
       prefix: "docker"
     ignore:
-      - dependency-name: "golang"
+      - dependency-name: "amd64/golang"
         versions:
           - ">= 1.21"
           - "< 1.20"
@@ -383,7 +383,7 @@ updates:
     commit-message:
       prefix: "docker"
     ignore:
-      - dependency-name: "golang"
+      - dependency-name: "amd64/golang"
         versions:
           - ">= 1.22"
           - "< 1.21"


### PR DESCRIPTION
## Changes

Replace generic `golang` dependency name with the architecture specific `amd64/golang` pattern to match recent Dockerfile updates.

## References

- fixes GH-1387
- https://github.com/atc0005/go-ci/pull/1371