### PR TITLE
Use builder/final pattern for stable Dockerfile

### DIFF
--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -7,7 +7,101 @@
 
 # https://hub.docker.com/_/golang
 
-FROM amd64/golang:1.22.0-bookworm
+FROM amd64/golang:1.22.0-bookworm as builder
+
+# Explicitly disable automatic fetching of Go toolchains newer than the
+# version explicitly provided by this container image.
+#
+# https://github.com/atc0005/go-ci/issues/1188
+ENV GOTOOLCHAIN="local"
+
+ENV GOLANGCI_LINT_VERSION="v1.56.2"
+ENV STATICCHECK_VERSION="v0.4.6"
+ENV GOVULNCHECK_VERSION="v1.0.4"
+ENV HTTPERRORYZER_VERSION="v0.0.1"
+ENV STRUCTSLOP_VERSION="v0.0.8"
+ENV TICKERYZER_VERSION="v0.0.3"
+ENV TOMLL_VERSION="v2.1.1"
+ENV ERRWRAP_VERSION="v1.6.0"
+
+# These commits/versions are provided by temporary forks of the upstream
+# projects. The plan is to switch back to current upstream vesions once
+# the required dependencies are updated for those upstream projects.
+ENV HTTPERRORYZER_VERSION="54c26d99b9758117957285a790c2d88b51a552dd"
+ENV STRUCTSLOP_VERSION="55db8be618045ec870098a4579bae376bbb7df33"
+ENV TICKERYZER_VERSION="66a42ca5c152aced76c5186e92a4ae653440f02d"
+# ENV ERRWRAP_VERSION="c75521dd38c3bf43d1acaf3f628d87252fa69270"
+
+ENV APT_BSDMAINUTILS_VERSION="12.1.8"
+ENV APT_TREE_VERSION="2.1.0-1"
+
+RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
+    && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
+    && staticcheck --version
+
+# RUN echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
+#     && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
+#     && echo "Installing httperroryzer@${HTTPERRORYZER_VERSION}" \
+#     && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
+#     && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
+#     && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
+#     && echo "Installing tickeryzer@${TICKERYZER_VERSION}" \
+#     && go install github.com/orijtech/tickeryzer/cmd/tickeryzer@${TICKERYZER_VERSION} \
+#     && echo "Installing tomll@${TOMLL_VERSION}" \
+#     && go install github.com/pelletier/go-toml/v2/cmd/tomll@${TOMLL_VERSION} \
+#     && echo "Installing errwrap@${ERRWRAP_VERSION}" \
+#     && go install github.com/fatih/errwrap@${ERRWRAP_VERSION}
+
+RUN echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
+    && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
+    && echo "Installing tomll@${TOMLL_VERSION}" \
+    && go install github.com/pelletier/go-toml/v2/cmd/tomll@${TOMLL_VERSION}
+
+RUN echo "Installing httperroryzer from temporary fork" \
+    && git clone https://github.com/atc0005/httperroryzer \
+    && cd httperroryzer \
+    && git checkout ${HTTPERRORYZER_VERSION} \
+    && go install ./cmd/httperroryzer \
+    && cd ..
+
+RUN echo "Installing structslop from temporary fork" \
+    && git clone https://github.com/atc0005/structslop \
+    && cd structslop \
+    && git checkout ${STRUCTSLOP_VERSION} \
+    && go install ./cmd/structslop \
+    && cd ..
+
+RUN echo "Installing tickeryzer from temporary fork" \
+    && git clone https://github.com/atc0005/tickeryzer \
+    && cd tickeryzer \
+    && git checkout ${TICKERYZER_VERSION} \
+    && go install ./cmd/tickeryzer \
+    && cd ..
+
+RUN echo "Installing errwrap@${ERRWRAP_VERSION}" \
+    && go install github.com/fatih/errwrap@${ERRWRAP_VERSION}
+
+# RUN echo "Installing errwrap from temporary fork" \
+#     && git clone https://github.com/atc0005/errwrap \
+#     && cd errwrap \
+#     && git checkout ${ERRWRAP_VERSION} \
+#     && go install . \
+#     && cd ..
+
+# RUN echo "Installing golangci-lint from dev feat/go1.20 branch" \
+#     && git clone https://github.com/atc0005/golangci-lint \
+#     && cd golangci-lint \
+#     && git checkout ${GOLANGCI_LINT_VERSION} \
+#     && go install ./cmd/golangci-lint \
+#     && golangci-lint --version
+
+RUN echo "Installing golangci-lint@${GOLANGCI_LINT_VERSION}" \
+    && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
+    && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+    && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
+    && golangci-lint --version
+
+FROM amd64/golang:1.22.0-bookworm as final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -43,28 +137,16 @@ RUN apt-get update \
     bsdmainutils=${APT_BSDMAINUTILS_VERSION} \
     tree=${APT_TREE_VERSION} \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    \
-    && echo "Installing staticcheck@${STATICCHECK_VERSION}" \
-    && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
-    && staticcheck --version \
-    && echo "Installing govulncheck@${GOVULNCHECK_VERSION}" \
-    && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
-    && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
-    && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-    && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
-    && golangci-lint --version \
-    && echo "Installing httperroryzer@${HTTPERRORYZER_VERSION}" \
-    && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
-    && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
-    && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
-    && echo "Installing tickeryzer@${TICKERYZER_VERSION}" \
-    && go install github.com/orijtech/tickeryzer/cmd/tickeryzer@${TICKERYZER_VERSION} \
-    && echo "Installing tomll@${TOMLL_VERSION}" \
-    && go install github.com/pelletier/go-toml/v2/cmd/tomll@${TOMLL_VERSION} \
-    && echo "Installing errwrap@${ERRWRAP_VERSION}" \
-    && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
-    && go clean -cache -modcache
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /go/bin/staticcheck /usr/bin/staticcheck
+COPY --from=builder /go/bin/golangci-lint /usr/bin/golangci-lint
+COPY --from=builder /go/bin/govulncheck /usr/bin/govulncheck
+COPY --from=builder /go/bin/httperroryzer /usr/bin/httperroryzer
+COPY --from=builder /go/bin/structslop /usr/bin/structslop
+COPY --from=builder /go/bin/tickeryzer /usr/bin/tickeryzer
+COPY --from=builder /go/bin/tomll /usr/bin/tomll
+COPY --from=builder /go/bin/errwrap /usr/bin/errwrap
 
 # Copy over linting config files to root of container image to serve as a
 # default. The Makefile copies in these files as Docker requires that the


### PR DESCRIPTION
## Changes

Mirror the setup used by the unstable combined Dockerfile.

This allows us to more easily generate custom builds (with updated dependencies) of orijtech linters until the upstream versions are patched.

## References

- fixes GH-1400