### PR TITLE
Fix mingw-w64 Dependabot ignore dep name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -328,7 +328,7 @@ updates:
     commit-message:
       prefix: "General Build Image"
     ignore:
-      - dependency-name: "amd64/golang"
+      - dependency-name: "i386/golang"
         versions:
           - ">= 1.22"
           - "< 1.21"
@@ -374,7 +374,7 @@ updates:
     commit-message:
       prefix: "General Build Image"
     ignore:
-      - dependency-name: "amd64/golang"
+      - dependency-name: "i386/golang"
         versions:
           - ">= 1.23"
           - "< 1.22"


### PR DESCRIPTION
Use `i386/golang` dependency name as intended for 32-bit images as intended instead of `amd64/golang`.

refs GH-1442
refs GH-1443