### PR TITLE
Add Fyle toolkit dependencies to mingw-64 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ the `*-mirror-*` images:
 - supports cross-platform, cgo-enabled builds for Windows and Linux
   - Windows 32-bit: `i686-w64-mingw32-gcc`
   - Windows 64-bit: `x86_64-w64-mingw32-gcc`
+- ✔️ provides [Fyne toolkit build dependencies](https://docs.fyne.io/started/)
 - ✔️ provides multiple [custom build tools](#build-tools-included)
 - ❌ does not include [linters](#linting-tools-included)
 
@@ -218,6 +219,7 @@ the `*-mirror-*` images:
 - same as `go-ci-oldstable-cgo-mingw-w64-buildx86`, but specific to x64
   architecture
 - ✔️ provides multiple [custom build tools](#build-tools-included)
+- ✔️ provides [Fyne toolkit build dependencies](https://docs.fyne.io/started/)
 - ❌ does not include [linters](#linting-tools-included)
 
 #### `go-ci-stable-cgo-mingw-w64-buildx86`
@@ -229,6 +231,7 @@ the `*-mirror-*` images:
   - Windows 32-bit: `i686-w64-mingw32-gcc`
   - Windows 64-bit: `x86_64-w64-mingw32-gcc`
 - ✔️ provides multiple [custom build tools](#build-tools-included)
+- ✔️ provides [Fyne toolkit build dependencies](https://docs.fyne.io/started/)
 - ❌ does not include [linters](#linting-tools-included)
 
 #### `go-ci-stable-cgo-mingw-w64-buildx64`
@@ -236,6 +239,7 @@ the `*-mirror-*` images:
 - same as `go-ci-stable-cgo-mingw-w64-buildx86`, but specific to x64
   architecture
 - ✔️ provides multiple [custom build tools](#build-tools-included)
+- ✔️ provides [Fyne toolkit build dependencies](https://docs.fyne.io/started/)
 - ❌ does not include [linters](#linting-tools-included)
 
 #### `go-ci-unstable-cgo-mingw-w64-buildx86`
@@ -248,6 +252,7 @@ the `*-mirror-*` images:
   - Windows 32-bit: `i686-w64-mingw32-gcc`
   - Windows 64-bit: `x86_64-w64-mingw32-gcc`
 - ✔️ provides multiple [custom build tools](#build-tools-included)
+- ✔️ provides [Fyne toolkit build dependencies](https://docs.fyne.io/started/)
 - ❌ does not include [linters](#linting-tools-included)
 
 #### `go-ci-unstable-cgo-mingw-w64-buildx64`
@@ -255,6 +260,7 @@ the `*-mirror-*` images:
 - same as `go-ci-unstable-cgo-mingw-w64-buildx86`, but specific to x64
   architecture
 - ✔️ provides multiple [custom build tools](#build-tools-included)
+- ✔️ provides [Fyne toolkit build dependencies](https://docs.fyne.io/started/)
 - ❌ does not include [linters](#linting-tools-included)
 
 ### Mirror build images

--- a/oldstable/build/cgo-mingw-w64-x64/Dockerfile
+++ b/oldstable/build/cgo-mingw-w64-x64/Dockerfile
@@ -33,6 +33,11 @@ ENV APT_GCC_MULTILIB_VERSION="4:12.2.0-3"
 ENV APT_GCC_MINGW_W64_VERSION="12.2.0-14+25.2"
 ENV XZ_UTILS_VERSION="5.4.1-0.2"
 
+# https://docs.fyne.io/started/
+ENV APT_GCC_VERSION="4:12.2.0-3"
+ENV APT_LIBGL1_MESA_DEV_VERSION="22.3.6-1+deb12u1"
+ENV APT_XORG_DEV_VERSION="1:7.7+23"
+
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.1"
 
@@ -49,6 +54,9 @@ RUN apt-get update \
     gcc-multilib="${APT_GCC_MULTILIB_VERSION}" \
     gcc-mingw-w64="${APT_GCC_MINGW_W64_VERSION}" \
     xz-utils="${XZ_UTILS_VERSION}" \
+    gcc="${APT_GCC_VERSION}" \
+    libgl1-mesa-dev="${APT_LIBGL1_MESA_DEV_VERSION}" \
+    xorg-dev="${APT_XORG_DEV_VERSION}" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \

--- a/oldstable/build/cgo-mingw-w64-x86/Dockerfile
+++ b/oldstable/build/cgo-mingw-w64-x86/Dockerfile
@@ -33,6 +33,11 @@ ENV APT_GCC_MULTILIB_VERSION="4:12.2.0-3"
 ENV APT_GCC_MINGW_W64_VERSION="12.2.0-14+25.2"
 ENV XZ_UTILS_VERSION="5.4.1-0.2"
 
+# https://docs.fyne.io/started/
+ENV APT_GCC_VERSION="4:12.2.0-3"
+ENV APT_LIBGL1_MESA_DEV_VERSION="22.3.6-1+deb12u1"
+ENV APT_XORG_DEV_VERSION="1:7.7+23"
+
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.1"
 
@@ -49,6 +54,9 @@ RUN apt-get update \
     gcc-multilib="${APT_GCC_MULTILIB_VERSION}" \
     gcc-mingw-w64="${APT_GCC_MINGW_W64_VERSION}" \
     xz-utils="${XZ_UTILS_VERSION}" \
+    gcc="${APT_GCC_VERSION}" \
+    libgl1-mesa-dev="${APT_LIBGL1_MESA_DEV_VERSION}" \
+    xorg-dev="${APT_XORG_DEV_VERSION}" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \

--- a/stable/build/cgo-mingw-w64-x64/Dockerfile
+++ b/stable/build/cgo-mingw-w64-x64/Dockerfile
@@ -33,6 +33,11 @@ ENV APT_GCC_MULTILIB_VERSION="4:12.2.0-3"
 ENV APT_GCC_MINGW_W64_VERSION="12.2.0-14+25.2"
 ENV XZ_UTILS_VERSION="5.4.1-0.2"
 
+# https://docs.fyne.io/started/
+ENV APT_GCC_VERSION="4:12.2.0-3"
+ENV APT_LIBGL1_MESA_DEV_VERSION="22.3.6-1+deb12u1"
+ENV APT_XORG_DEV_VERSION="1:7.7+23"
+
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.1"
 
@@ -49,6 +54,9 @@ RUN apt-get update \
     gcc-multilib="${APT_GCC_MULTILIB_VERSION}" \
     gcc-mingw-w64="${APT_GCC_MINGW_W64_VERSION}" \
     xz-utils="${XZ_UTILS_VERSION}" \
+    gcc="${APT_GCC_VERSION}" \
+    libgl1-mesa-dev="${APT_LIBGL1_MESA_DEV_VERSION}" \
+    xorg-dev="${APT_XORG_DEV_VERSION}" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \

--- a/stable/build/cgo-mingw-w64-x86/Dockerfile
+++ b/stable/build/cgo-mingw-w64-x86/Dockerfile
@@ -33,6 +33,11 @@ ENV APT_GCC_MULTILIB_VERSION="4:12.2.0-3"
 ENV APT_GCC_MINGW_W64_VERSION="12.2.0-14+25.2"
 ENV XZ_UTILS_VERSION="5.4.1-0.2"
 
+# https://docs.fyne.io/started/
+ENV APT_GCC_VERSION="4:12.2.0-3"
+ENV APT_LIBGL1_MESA_DEV_VERSION="22.3.6-1+deb12u1"
+ENV APT_XORG_DEV_VERSION="1:7.7+23"
+
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.1"
 
@@ -49,6 +54,9 @@ RUN apt-get update \
     gcc-multilib="${APT_GCC_MULTILIB_VERSION}" \
     gcc-mingw-w64="${APT_GCC_MINGW_W64_VERSION}" \
     xz-utils="${XZ_UTILS_VERSION}" \
+    gcc="${APT_GCC_VERSION}" \
+    libgl1-mesa-dev="${APT_LIBGL1_MESA_DEV_VERSION}" \
+    xorg-dev="${APT_XORG_DEV_VERSION}" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \

--- a/unstable/build/cgo-mingw-w64-x64/Dockerfile
+++ b/unstable/build/cgo-mingw-w64-x64/Dockerfile
@@ -33,6 +33,11 @@ ENV APT_GCC_MULTILIB_VERSION="4:12.2.0-3"
 ENV APT_GCC_MINGW_W64_VERSION="12.2.0-14+25.2"
 ENV XZ_UTILS_VERSION="5.4.1-0.2"
 
+# https://docs.fyne.io/started/
+ENV APT_GCC_VERSION="4:12.2.0-3"
+ENV APT_LIBGL1_MESA_DEV_VERSION="22.3.6-1+deb12u1"
+ENV APT_XORG_DEV_VERSION="1:7.7+23"
+
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.1"
 
@@ -49,6 +54,9 @@ RUN apt-get update \
     gcc-multilib="${APT_GCC_MULTILIB_VERSION}" \
     gcc-mingw-w64="${APT_GCC_MINGW_W64_VERSION}" \
     xz-utils="${XZ_UTILS_VERSION}" \
+    gcc="${APT_GCC_VERSION}" \
+    libgl1-mesa-dev="${APT_LIBGL1_MESA_DEV_VERSION}" \
+    xorg-dev="${APT_XORG_DEV_VERSION}" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \

--- a/unstable/build/cgo-mingw-w64-x86/Dockerfile
+++ b/unstable/build/cgo-mingw-w64-x86/Dockerfile
@@ -33,6 +33,11 @@ ENV APT_GCC_MULTILIB_VERSION="4:12.2.0-3"
 ENV APT_GCC_MINGW_W64_VERSION="12.2.0-14+25.2"
 ENV XZ_UTILS_VERSION="5.4.1-0.2"
 
+# https://docs.fyne.io/started/
+ENV APT_GCC_VERSION="4:12.2.0-3"
+ENV APT_LIBGL1_MESA_DEV_VERSION="22.3.6-1+deb12u1"
+ENV APT_XORG_DEV_VERSION="1:7.7+23"
+
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.1"
 
@@ -49,6 +54,9 @@ RUN apt-get update \
     gcc-multilib="${APT_GCC_MULTILIB_VERSION}" \
     gcc-mingw-w64="${APT_GCC_MINGW_W64_VERSION}" \
     xz-utils="${XZ_UTILS_VERSION}" \
+    gcc="${APT_GCC_VERSION}" \
+    libgl1-mesa-dev="${APT_LIBGL1_MESA_DEV_VERSION}" \
+    xorg-dev="${APT_XORG_DEV_VERSION}" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \


### PR DESCRIPTION
## Changes

Add deps:

- `gcc`
- `libgl1-mesa-dev`
- `xorg-dev`

Update README to list provided dependencies within mingw-64 images.

## References

- fixes GH-1446