### PR TITLE
Fix monthly scheduled tasks workflow (redux)

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -75,15 +75,6 @@ jobs:
   build_and_upload_mirror_images:
     name: Build and upload mirror container images
     needs: git_describe_semver
-
-    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-    permissions:
-      contents: write
-      discussions: write
-      packages: write
-
-    if: startsWith(github.ref, 'refs/tags')
-
     runs-on: ubuntu-latest
     # Default: 360 minutes
     timeout-minutes: 45
@@ -126,15 +117,6 @@ jobs:
   build_and_upload_alpine_images:
     name: Build and upload Alpine container images
     needs: git_describe_semver
-
-    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-    permissions:
-      contents: write
-      discussions: write
-      packages: write
-
-    if: startsWith(github.ref, 'refs/tags')
-
     runs-on: ubuntu-latest
     # Default: 360 minutes
     timeout-minutes: 45
@@ -177,15 +159,6 @@ jobs:
   build_and_upload_mingw_images:
     name: Build and upload mingw-w64 container images
     needs: git_describe_semver
-
-    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-    permissions:
-      contents: write
-      discussions: write
-      packages: write
-
-    if: startsWith(github.ref, 'refs/tags')
-
     runs-on: ubuntu-latest
     # Default: 360 minutes
     timeout-minutes: 45
@@ -228,15 +201,6 @@ jobs:
   build_and_upload_standard_images:
     name: Build and upload standard container images
     needs: git_describe_semver
-
-    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-    permissions:
-      contents: write
-      discussions: write
-      packages: write
-
-    if: startsWith(github.ref, 'refs/tags')
-
     runs-on: ubuntu-latest
     # Default: 360 minutes
     timeout-minutes: 45


### PR DESCRIPTION
Remove settings specific to the release builds workflow which do not apply to the monthly schedule tasks workflow (lack of upload task and need for token/perms).

refs GH-1465
refs GH-1451