### PR TITLE
Rename `goerr113` linter to `err113`

### DIFF
--- a/unstable/combined/.golangci.yml
+++ b/unstable/combined/.golangci.yml
@@ -36,14 +36,14 @@ linters:
     # - depguard
     - dogsled
     - dupl
-    - exportloopref
+    - err113
     - errcheck
+    - exportloopref
     - gochecknoglobals
     - gocognit
     - goconst
     - gocritic
     - gocyclo
-    - goerr113
     - gofmt
     - goimports
     - gosec


### PR DESCRIPTION
Resolve golangci-lint warning regarding deprecated name of linter active in the config file for the `unstable` image.

Sort linters list alphabetically.

fixes GH-1543