### PR TITLE
Skip adding tools Dependabot PRs to release notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,7 @@ updates:
       - "atc0005"
     labels:
       - "dependencies"
+      - "ignore-for-release"
 
     allow:
       # Allow both direct and indirect updates for all packages


### PR DESCRIPTION
Those PRs are intended to serve as reminders to update the pinned versions in Dockerfiles and only clutter release notes.