### PR TITLE
Remove `orijtech/structslop` from unstable image

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,20 +69,20 @@ others.
 
 ## Linting tools included
 
-The following linting tools are included in the `go-ci-stable`,
-`go-ci-oldstable` and `go-ci-unstable` images:
+Unless indicated otherwise, the following linting tools are included in the
+`go-ci-stable`, `go-ci-oldstable` and `go-ci-unstable` images:
 
-| Linter                                                                | Version               |
-| --------------------------------------------------------------------- | --------------------- |
-| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2023.1.7` (`v0.4.7`) |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.59.1`             |
-| [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `v1.1.2`              |
-| [`deadcode`](https://pkg.go.dev/golang.org/x/tools/cmd/deadcode)      | `v0.22.0`             |
-| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`              |
-| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.8`              |
-| [`orijtech/tickeryzer`](https://github.com/orijtech/tickeryzer)       | `v0.0.3`              |
-| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.2.2`              |
-| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.6.0`              |
+| Linter                                                                | Version                               |
+| --------------------------------------------------------------------- | ------------------------------------- |
+| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2023.1.7` (`v0.4.7`)                 |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.59.1`                             |
+| [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `v1.1.2`                              |
+| [`deadcode`](https://pkg.go.dev/golang.org/x/tools/cmd/deadcode)      | `v0.22.0`                             |
+| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1`                              |
+| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.8` (`oldstable`, `stable` only) |
+| [`orijtech/tickeryzer`](https://github.com/orijtech/tickeryzer)       | `v0.0.3`                              |
+| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.2.2`                              |
+| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.6.0`                              |
 
 ## Build tools included
 

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -27,7 +27,6 @@ ENV STATICCHECK_VERSION="v0.4.7"
 ENV DEADCODE_VERSION="v0.22.0"
 ENV GOVULNCHECK_VERSION="v1.1.2"
 # ENV HTTPERRORYZER_VERSION="v0.0.1"
-# ENV STRUCTSLOP_VERSION="v0.0.8"
 # ENV TICKERYZER_VERSION="v0.0.3"
 ENV TOMLL_VERSION="v2.2.2"
 ENV ERRWRAP_VERSION="v1.6.0"
@@ -37,7 +36,6 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 # projects. The plan is to switch back to current upstream vesions once
 # the required dependencies are updated for those upstream projects.
 ENV HTTPERRORYZER_VERSION="54c26d99b9758117957285a790c2d88b51a552dd"
-ENV STRUCTSLOP_VERSION="55db8be618045ec870098a4579bae376bbb7df33"
 ENV TICKERYZER_VERSION="66a42ca5c152aced76c5186e92a4ae653440f02d"
 # ENV ERRWRAP_VERSION="c75521dd38c3bf43d1acaf3f628d87252fa69270"
 
@@ -49,8 +47,6 @@ RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
 #     && go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
 #     && echo "Installing httperroryzer@${HTTPERRORYZER_VERSION}" \
 #     && go install github.com/orijtech/httperroryzer/cmd/httperroryzer@${HTTPERRORYZER_VERSION} \
-#     && echo "Installing structslop@${STRUCTSLOP_VERSION}" \
-#     && go install github.com/orijtech/structslop/cmd/structslop@${STRUCTSLOP_VERSION} \
 #     && echo "Installing tickeryzer@${TICKERYZER_VERSION}" \
 #     && go install github.com/orijtech/tickeryzer/cmd/tickeryzer@${TICKERYZER_VERSION} \
 #     && echo "Installing tomll@${TOMLL_VERSION}" \
@@ -72,13 +68,6 @@ RUN echo "Installing httperroryzer from temporary fork" \
     && cd httperroryzer \
     && git checkout ${HTTPERRORYZER_VERSION} \
     && go install ./cmd/httperroryzer \
-    && cd ..
-
-RUN echo "Installing structslop from temporary fork" \
-    && git clone https://github.com/atc0005/structslop \
-    && cd structslop \
-    && git checkout ${STRUCTSLOP_VERSION} \
-    && go install ./cmd/structslop \
     && cd ..
 
 RUN echo "Installing tickeryzer from temporary fork" \
@@ -144,7 +133,6 @@ ENV STATICCHECK_VERSION="v0.4.7"
 ENV DEADCODE_VERSION="v0.22.0"
 ENV GOVULNCHECK_VERSION="v1.1.2"
 ENV HTTPERRORYZER_VERSION="v0.0.1"
-ENV STRUCTSLOP_VERSION="v0.0.8"
 ENV TOMLL_VERSION="v2.2.2"
 ENV ERRWRAP_VERSION="v1.6.0"
 ENV GOTESTDOX_VERSION="v0.2.2"
@@ -165,7 +153,6 @@ COPY --from=builder /go/bin/govulncheck /usr/bin/govulncheck
 COPY --from=builder /go/bin/deadcode /usr/bin/deadcode
 COPY --from=builder /go/bin/gotestdox /usr/bin/gotestdox
 COPY --from=builder /go/bin/httperroryzer /usr/bin/httperroryzer
-COPY --from=builder /go/bin/structslop /usr/bin/structslop
 COPY --from=builder /go/bin/tickeryzer /usr/bin/tickeryzer
 COPY --from=builder /go/bin/tomll /usr/bin/tomll
 COPY --from=builder /go/bin/errwrap /usr/bin/errwrap


### PR DESCRIPTION
## Overview

The latest upstream version of this linter fails to build using Go 1.23rc1. The linter is retained in the oldstable and stable images for now as the forked/patched version continues to build using Go 1.21 and Go 1.22.

## Refereces

- fixes GH-1585
- refs GH-1583