### PR TITLE
Fix GOLANGCI_LINT_VERSION tag in final stage

### DIFF
--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -124,7 +124,8 @@ ENV GOTOOLCHAIN="local"
 # A current dev branch build (mirrored to fork) is used for pre-release Go
 # versions, otherwise the latest upstream build of the tool is installed in
 # this image.
-ENV GOLANGCI_LINT_VERSION="v1.59.1"
+# ENV GOLANGCI_LINT_VERSION="v1.59.1"
+ENV GOLANGCI_LINT_VERSION="feat/go1.23"
 
 # A current master branch build is used for pre-release Go versions, otherwise
 # the latest upstream build of the tool is installed in this image.


### PR DESCRIPTION
Missed this when prepping changes for GH-1591.