### PR TITLE
Update staticcheck in unstable img to v0.5.0-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,18 @@ others.
 Unless indicated otherwise, the following linting tools are included in the
 `go-ci-stable`, `go-ci-oldstable` and `go-ci-unstable` images:
 
-| Linter                                                                | Version                                                                                                                  |
-| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2023.1.7` (`v0.4.7`) (`stable` and `oldstable` images)                                                                  |
-| [`staticcheck`](https://github.com/dominikh/go-tools)                 | [master branch](https://github.com/dominikh/go-tools/commit/dec278f2f0d94b07c04db075d807e9f499f5d7b5) (`unstable` image) |
-| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.59.1` (`stable` and `oldstable` images)                                                                              |
-| [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `v1.1.2`                                                                                                                 |
-| [`deadcode`](https://pkg.go.dev/golang.org/x/tools/cmd/deadcode)      | `v0.22.0`                                                                                                                |
-| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1` (`oldstable` image)                                                                                             |
-| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.8` (`oldstable` image)                                                                                             |
-| [`orijtech/tickeryzer`](https://github.com/orijtech/tickeryzer)       | `v0.0.3` (`oldstable` image)                                                                                             |
-| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.2.2`                                                                                                                 |
-| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.6.0`                                                                                                                 |
+| Linter                                                                | Version                                                 |
+| --------------------------------------------------------------------- | ------------------------------------------------------- |
+| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2023.1.7` (`v0.4.7`) (`stable` and `oldstable` images) |
+| [`staticcheck`](https://github.com/dominikh/go-tools)                 | `2024.1rc1` (`v0.5.0-rc.1`) (`unstable` image)          |
+| [`golangci-lint`](https://github.com/golangci/golangci-lint)          | `v1.59.1` (`stable` and `oldstable` images)             |
+| [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `v1.1.2`                                                |
+| [`deadcode`](https://pkg.go.dev/golang.org/x/tools/cmd/deadcode)      | `v0.22.0`                                               |
+| [`orijtech/httperroryzer`](https://github.com/orijtech/httperroryzer) | `v0.0.1` (`oldstable` image)                            |
+| [`orijtech/structslop`](https://github.com/orijtech/structslop)       | `v0.0.8` (`oldstable` image)                            |
+| [`orijtech/tickeryzer`](https://github.com/orijtech/tickeryzer)       | `v0.0.3` (`oldstable` image)                            |
+| [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.2.2`                                                |
+| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.6.0`                                                |
 
 Forks:
 

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -24,7 +24,8 @@ ENV GOLANGCI_LINT_VERSION="feat/go1.23"
 # A current master branch build is used for pre-release Go versions, otherwise
 # the latest upstream build of the tool is installed in this image.
 # ENV STATICCHECK_VERSION="v0.4.7"
-ENV STATICCHECK_VERSION="dec278f2f0d94b07c04db075d807e9f499f5d7b5"
+# ENV STATICCHECK_VERSION="dec278f2f0d94b07c04db075d807e9f499f5d7b5"
+ENV STATICCHECK_VERSION="v0.5.0-rc.1"
 
 ENV DEADCODE_VERSION="v0.22.0"
 ENV GOVULNCHECK_VERSION="v1.1.2"
@@ -128,10 +129,9 @@ ENV GOTOOLCHAIN="local"
 # ENV GOLANGCI_LINT_VERSION="v1.59.1"
 ENV GOLANGCI_LINT_VERSION="feat/go1.23"
 
-# A current master branch build is used for pre-release Go versions, otherwise
-# the latest upstream build of the tool is installed in this image.
 # ENV STATICCHECK_VERSION="v0.4.7"
-ENV STATICCHECK_VERSION="dec278f2f0d94b07c04db075d807e9f499f5d7b5"
+# ENV STATICCHECK_VERSION="dec278f2f0d94b07c04db075d807e9f499f5d7b5"
+ENV STATICCHECK_VERSION="v0.5.0-rc.1"
 
 # These commits/versions are provided by temporary forks of the upstream
 # projects. The plan is to switch back to current upstream vesions once


### PR DESCRIPTION
Switch from commit dec278f2f0d94b07c04db075d807e9f499f5d7b5 on master branch to latest v0.5.0 pre-release version.

Update README to list updated version of staticheck in unstable image.

refs GH-1596
