### PR TITLE
Add `file` for stable, oldstable and unstable imgs

### DIFF
--- a/oldstable/combined/Dockerfile
+++ b/oldstable/combined/Dockerfile
@@ -39,11 +39,13 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
+ENV APT_FILE_VERSION="1:5.44-3"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     bsdmainutils=${APT_BSDMAINUTILS_VERSION} \
     tree=${APT_TREE_VERSION} \
+    file=${APT_FILE_VERSION} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     \

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -146,11 +146,13 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
+ENV APT_FILE_VERSION="1:5.44-3"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     bsdmainutils=${APT_BSDMAINUTILS_VERSION} \
     tree=${APT_TREE_VERSION} \
+    file=${APT_FILE_VERSION} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -148,11 +148,13 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
+ENV APT_FILE_VERSION="1:5.44-3"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     bsdmainutils=${APT_BSDMAINUTILS_VERSION} \
     tree=${APT_TREE_VERSION} \
+    file=${APT_FILE_VERSION} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Changes

Add `file` to linting images:

- `go-ci-stable`
- `go-ci-oldstable`
- `go-ci-unstable`

This provides the requested tool for use with CodeQL GitHub Actions jobs.

## References

- fixes GH-1636