### PR TITLE
Bump golangci-lint Go 1.23 support to 2024-07-31

### DIFF
--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -19,7 +19,7 @@ ENV GOTOOLCHAIN="local"
 # versions, otherwise the latest upstream build of the tool is installed in
 # this image.
 # ENV GOLANGCI_LINT_VERSION="v1.59.1"
-ENV GOLANGCI_LINT_VERSION="FORK-go1.23-support-2024-07-18"
+ENV GOLANGCI_LINT_VERSION="FORK-go1.23-support-2024-07-31"
 
 # A current master branch build is used for pre-release Go versions, otherwise
 # the latest upstream build of the tool is installed in this image.
@@ -127,7 +127,7 @@ ENV GOTOOLCHAIN="local"
 # versions, otherwise the latest upstream build of the tool is installed in
 # this image.
 # ENV GOLANGCI_LINT_VERSION="v1.59.1"
-ENV GOLANGCI_LINT_VERSION="FORK-go1.23-support-2024-07-18"
+ENV GOLANGCI_LINT_VERSION="FORK-go1.23-support-2024-07-31"
 
 # ENV STATICCHECK_VERSION="v0.4.7"
 # ENV STATICCHECK_VERSION="dec278f2f0d94b07c04db075d807e9f499f5d7b5"


### PR DESCRIPTION
## Changes

Update fixed tag from `2024-07-18` to `2024-07-31` to pull in the latest Go 1.23 support changes.

## References

- GH-1591
- GH-1657