### PR TITLE
Update stable img structslop install options

### DIFF
--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -70,11 +70,12 @@ RUN echo "Installing httperroryzer from temporary fork" \
     && go install ./cmd/httperroryzer \
     && cd ..
 
+# https://github.com/orijtech/structslop/issues/64
 RUN echo "Installing structslop from temporary fork" \
     && git clone https://github.com/atc0005/structslop \
     && cd structslop \
     && git checkout ${STRUCTSLOP_VERSION} \
-    && go install ./cmd/structslop \
+    && go install -ldflags=-checklinkname=0 ./cmd/structslop \
     && cd ..
 
 RUN echo "Installing tickeryzer from temporary fork" \


### PR DESCRIPTION
## Changes

Explicitly use `-ldflags=-checklinkname=0` when building the linter to work around changes in Go 1.23 now that this image has has switched from providing Go 1.22 to 1.23.

## References

- GH-1666
- GH-1684