### PR TITLE
Update `orijtech` linters for Go 1.23 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Forks:
 | Linter                                                               | Version                                                                                                    |
 | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | [`golangci-lint`](https://github.com/golangci/golangci-lint)         | [`feat/go1.23` dev branch](https://github.com/atc0005/golangci-lint/tree/feat/go1.23) for `unstable` image |
-| [`orijtech/httperroryzer`](https://github.com/atc0005/httperroryzer) | `54c26d99b9758117957285a790c2d88b51a552dd` (`stable`, `unstable` images)                                   |
-| [`orijtech/structslop`](https://github.com/atc0005/structslop)       | `55db8be618045ec870098a4579bae376bbb7df33` (`stable`, `unstable` images)                                   |
-| [`orijtech/tickeryzer`](https://github.com/atc0005/tickeryzer)       | `66a42ca5c152aced76c5186e92a4ae653440f02d` (`stable`, `unstable` images)                                   |
+| [`orijtech/httperroryzer`](https://github.com/atc0005/httperroryzer) | `9f94717820d4a5075117680de2ca07875d32c9f1` (`stable`, `unstable` images)                                   |
+| [`orijtech/structslop`](https://github.com/atc0005/structslop)       | `33c868804e9e6070fdaee64b729d3129bbe85a53` (`stable`, `unstable` images)                                   |
+| [`orijtech/tickeryzer`](https://github.com/atc0005/tickeryzer)       | `b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f` (`stable`, `unstable` images)                                   |
 
 ## Build tools included
 

--- a/oldstable/combined/Dockerfile
+++ b/oldstable/combined/Dockerfile
@@ -29,9 +29,9 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 # These commits/versions are provided by temporary forks of the upstream
 # projects. The plan is to switch back to current upstream vesions once
 # the required dependencies are updated for those upstream projects.
-ENV HTTPERRORYZER_VERSION="54c26d99b9758117957285a790c2d88b51a552dd"
-ENV STRUCTSLOP_VERSION="55db8be618045ec870098a4579bae376bbb7df33"
-ENV TICKERYZER_VERSION="66a42ca5c152aced76c5186e92a4ae653440f02d"
+ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
+ENV STRUCTSLOP_VERSION="33c868804e9e6070fdaee64b729d3129bbe85a53"
+ENV TICKERYZER_VERSION="b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f"
 # ENV ERRWRAP_VERSION="c75521dd38c3bf43d1acaf3f628d87252fa69270"
 
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
@@ -139,6 +139,14 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
 ENV APT_FILE_VERSION="1:5.44-3"
+
+# These commits/versions are provided by temporary forks of the upstream
+# projects. The plan is to switch back to current upstream vesions once
+# the required dependencies are updated for those upstream projects.
+ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
+ENV STRUCTSLOP_VERSION="33c868804e9e6070fdaee64b729d3129bbe85a53"
+ENV TICKERYZER_VERSION="b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f"
+# ENV ERRWRAP_VERSION="c75521dd38c3bf43d1acaf3f628d87252fa69270"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -29,9 +29,9 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 # These commits/versions are provided by temporary forks of the upstream
 # projects. The plan is to switch back to current upstream vesions once
 # the required dependencies are updated for those upstream projects.
-ENV HTTPERRORYZER_VERSION="54c26d99b9758117957285a790c2d88b51a552dd"
-ENV STRUCTSLOP_VERSION="55db8be618045ec870098a4579bae376bbb7df33"
-ENV TICKERYZER_VERSION="66a42ca5c152aced76c5186e92a4ae653440f02d"
+ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
+ENV STRUCTSLOP_VERSION="33c868804e9e6070fdaee64b729d3129bbe85a53"
+ENV TICKERYZER_VERSION="b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f"
 # ENV ERRWRAP_VERSION="c75521dd38c3bf43d1acaf3f628d87252fa69270"
 
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
@@ -130,9 +130,9 @@ ENV GOTOOLCHAIN="local"
 # These commits/versions are provided by temporary forks of the upstream
 # projects. The plan is to switch back to current upstream vesions once
 # the required dependencies are updated for those upstream projects.
-ENV HTTPERRORYZER_VERSION="54c26d99b9758117957285a790c2d88b51a552dd"
-ENV STRUCTSLOP_VERSION="55db8be618045ec870098a4579bae376bbb7df33"
-ENV TICKERYZER_VERSION="66a42ca5c152aced76c5186e92a4ae653440f02d"
+ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
+ENV STRUCTSLOP_VERSION="33c868804e9e6070fdaee64b729d3129bbe85a53"
+ENV TICKERYZER_VERSION="b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f"
 
 ENV GOLANGCI_LINT_VERSION="v1.59.1"
 ENV STATICCHECK_VERSION="v0.4.7"

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -39,9 +39,9 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 # These commits/versions are provided by temporary forks of the upstream
 # projects. The plan is to switch back to current upstream vesions once
 # the required dependencies are updated for those upstream projects.
-ENV HTTPERRORYZER_VERSION="54c26d99b9758117957285a790c2d88b51a552dd"
-ENV STRUCTSLOP_VERSION="55db8be618045ec870098a4579bae376bbb7df33"
-ENV TICKERYZER_VERSION="66a42ca5c152aced76c5186e92a4ae653440f02d"
+ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
+ENV STRUCTSLOP_VERSION="33c868804e9e6070fdaee64b729d3129bbe85a53"
+ENV TICKERYZER_VERSION="b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f"
 # ENV ERRWRAP_VERSION="c75521dd38c3bf43d1acaf3f628d87252fa69270"
 
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
@@ -148,9 +148,9 @@ ENV STATICCHECK_VERSION="v0.5.0-rc.1"
 # These commits/versions are provided by temporary forks of the upstream
 # projects. The plan is to switch back to current upstream vesions once
 # the required dependencies are updated for those upstream projects.
-ENV HTTPERRORYZER_VERSION="54c26d99b9758117957285a790c2d88b51a552dd"
-ENV STRUCTSLOP_VERSION="55db8be618045ec870098a4579bae376bbb7df33"
-ENV TICKERYZER_VERSION="66a42ca5c152aced76c5186e92a4ae653440f02d"
+ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
+ENV STRUCTSLOP_VERSION="33c868804e9e6070fdaee64b729d3129bbe85a53"
+ENV TICKERYZER_VERSION="b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f"
 
 ENV DEADCODE_VERSION="v0.24.0"
 ENV GOVULNCHECK_VERSION="v1.1.3"


### PR DESCRIPTION
Pull in latest dependencies refresh for the forked linters:

- https://github.com/atc0005/httperroryzer/commit/9f94717820d4a5075117680de2ca07875d32c9f1
- https://github.com/atc0005/tickeryzer/commit/b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f
- https://github.com/atc0005/structslop/commit/33c868804e9e6070fdaee64b729d3129bbe85a53

NOTE: Using those forks until the upstream repos are updated by maintainers *or* until we remove those linters from the linting images.

fixes GH-1685