### PR TITLE
Remove abandoned errwrap linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Unless indicated otherwise, the following linting tools are included in the
 | [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) | `v1.1.4`              |
 | [`deadcode`](https://pkg.go.dev/golang.org/x/tools/cmd/deadcode)      | `v0.29.0`             |
 | [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.2.3`              |
-| [`fatih/errwrap`](https://github.com/fatih/errwrap)                   | `v1.6.0`              |
 
 Forks:
 
@@ -433,7 +432,6 @@ each release of this project.
     - [orijtech/structslop](https://github.com/orijtech/structslop)
     - [orijtech/tickeryzer](https://github.com/orijtech/tickeryzer)
     - [pelletier/go-toml](https://github.com/pelletier/go-toml)
-    - [fatih/errwrap](https://github.com/fatih/errwrap)
 - Build Tools
   - [tc-hib/go-winres](https://github.com/tc-hib/go-winres)
   - [goreleaser/nfpm](https://github.com/goreleaser/nfpm)

--- a/oldstable/combined/Dockerfile
+++ b/oldstable/combined/Dockerfile
@@ -23,7 +23,6 @@ ENV GOVULNCHECK_VERSION="v1.1.4"
 # ENV STRUCTSLOP_VERSION="v0.0.8"
 # ENV TICKERYZER_VERSION="v0.0.3"
 ENV TOMLL_VERSION="v2.2.3"
-ENV ERRWRAP_VERSION="v1.6.0"
 ENV GOTESTDOX_VERSION="v0.2.2"
 
 # These commits/versions are provided by temporary forks of the upstream
@@ -32,7 +31,6 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
 ENV STRUCTSLOP_VERSION="33c868804e9e6070fdaee64b729d3129bbe85a53"
 ENV TICKERYZER_VERSION="b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f"
-# ENV ERRWRAP_VERSION="c75521dd38c3bf43d1acaf3f628d87252fa69270"
 
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
@@ -85,17 +83,6 @@ RUN echo "Installing tickeryzer from temporary fork" \
     && go version -m $(which tickeryzer) \
     && cd ..
 
-RUN echo "Installing errwrap@${ERRWRAP_VERSION}" \
-    && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
-    && go version -m $(which errwrap)
-
-# RUN echo "Installing errwrap from temporary fork" \
-#     && git clone https://github.com/atc0005/errwrap \
-#     && cd errwrap \
-#     && git checkout ${ERRWRAP_VERSION} \
-#     && go install . \
-#     && cd ..
-
 # RUN echo "Installing golangci-lint from dev feat/go1.20 branch" \
 #     && git clone https://github.com/atc0005/golangci-lint \
 #     && cd golangci-lint \
@@ -133,7 +120,6 @@ ENV STATICCHECK_VERSION="v0.5.1"
 ENV DEADCODE_VERSION="v0.29.0"
 ENV GOVULNCHECK_VERSION="v1.1.4"
 ENV TOMLL_VERSION="v2.2.3"
-ENV ERRWRAP_VERSION="v1.6.0"
 ENV GOTESTDOX_VERSION="v0.2.2"
 
 # These commits/versions are provided by temporary forks of the upstream
@@ -142,7 +128,6 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
 ENV STRUCTSLOP_VERSION="33c868804e9e6070fdaee64b729d3129bbe85a53"
 ENV TICKERYZER_VERSION="b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f"
-# ENV ERRWRAP_VERSION="c75521dd38c3bf43d1acaf3f628d87252fa69270"
 
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
@@ -165,7 +150,6 @@ COPY --from=builder /go/bin/httperroryzer /usr/bin/httperroryzer
 COPY --from=builder /go/bin/structslop /usr/bin/structslop
 COPY --from=builder /go/bin/tickeryzer /usr/bin/tickeryzer
 COPY --from=builder /go/bin/tomll /usr/bin/tomll
-COPY --from=builder /go/bin/errwrap /usr/bin/errwrap
 
 # Copy over linting config files to root of container image to serve as a
 # default. Projects bringing their own config files (e.g., via GitHub Actions)

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -30,7 +30,6 @@ ENV GOVULNCHECK_VERSION="v1.1.4"
 # ENV STRUCTSLOP_VERSION="v0.0.8"
 # ENV TICKERYZER_VERSION="v0.0.3"
 ENV TOMLL_VERSION="v2.2.3"
-ENV ERRWRAP_VERSION="v1.6.0"
 ENV GOTESTDOX_VERSION="v0.2.2"
 
 # These commits/versions are provided by temporary forks of the upstream
@@ -39,7 +38,6 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
 ENV STRUCTSLOP_VERSION="33c868804e9e6070fdaee64b729d3129bbe85a53"
 ENV TICKERYZER_VERSION="b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f"
-# ENV ERRWRAP_VERSION="c75521dd38c3bf43d1acaf3f628d87252fa69270"
 
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
@@ -90,17 +88,6 @@ RUN echo "Installing tickeryzer from temporary fork" \
     && go version -m $(which tickeryzer) \
     && cd ..
 
-RUN echo "Installing errwrap@${ERRWRAP_VERSION}" \
-    && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
-    && go version -m $(which errwrap)
-
-# RUN echo "Installing errwrap from temporary fork" \
-#     && git clone https://github.com/atc0005/errwrap \
-#     && cd errwrap \
-#     && git checkout ${ERRWRAP_VERSION} \
-#     && go install . \
-#     && cd ..
-
 # RUN echo "Installing golangci-lint from dev feat/go1.20 branch" \
 #     && git clone https://github.com/atc0005/golangci-lint \
 #     && cd golangci-lint \
@@ -150,7 +137,6 @@ ENV GOVULNCHECK_VERSION="v1.1.4"
 # ENV STRUCTSLOP_VERSION="v0.0.8"
 # ENV TICKERYZER_VERSION="v0.0.3"
 ENV TOMLL_VERSION="v2.2.3"
-ENV ERRWRAP_VERSION="v1.6.0"
 ENV GOTESTDOX_VERSION="v0.2.2"
 
 # These commits/versions are provided by temporary forks of the upstream
@@ -159,7 +145,6 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
 ENV STRUCTSLOP_VERSION="33c868804e9e6070fdaee64b729d3129bbe85a53"
 ENV TICKERYZER_VERSION="b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f"
-# ENV ERRWRAP_VERSION="c75521dd38c3bf43d1acaf3f628d87252fa69270"
 
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
@@ -182,7 +167,6 @@ COPY --from=builder /go/bin/httperroryzer /usr/bin/httperroryzer
 COPY --from=builder /go/bin/structslop /usr/bin/structslop
 COPY --from=builder /go/bin/tickeryzer /usr/bin/tickeryzer
 COPY --from=builder /go/bin/tomll /usr/bin/tomll
-COPY --from=builder /go/bin/errwrap /usr/bin/errwrap
 
 # Copy over linting config files to root of container image to serve as a
 # default. The Makefile copies in these files as Docker requires that the

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -9,9 +9,6 @@ require (
 	// https://github.com/bitfield/gotestdox
 	github.com/bitfield/gotestdox v0.2.2
 
-	// errwrap - provided as an optional linter
-	github.com/fatih/errwrap v1.6.0
-
 	// golangci-lint - intended as a primary linter
 	github.com/golangci/golangci-lint v1.63.4
 

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -49,8 +49,6 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/fatih/errwrap v1.6.0 h1:OvAnxNd0jmV7YYSCHBU8zCdepQG8X019hOanCDw+gZQ=
-github.com/fatih/errwrap v1.6.0/go.mod h1:gK9SnQPI2m9oGzMrOYa6tZFbdnltBdaSRzUth1SzSe4=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -12,7 +12,6 @@ package tools
 import (
 	_ "github.com/bitfield/gotestdox/cmd/gotestdox"
 	_ "github.com/choffmeister/git-describe-semver"
-	_ "github.com/fatih/errwrap"
 	_ "github.com/golangci/golangci-lint/pkg/config"
 	_ "github.com/goreleaser/nfpm/v2"
 	_ "github.com/orijtech/httperroryzer"

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -34,7 +34,6 @@ ENV GOVULNCHECK_VERSION="v1.1.4"
 # ENV STRUCTSLOP_VERSION="v0.0.8"
 # ENV TICKERYZER_VERSION="v0.0.3"
 ENV TOMLL_VERSION="v2.2.3"
-ENV ERRWRAP_VERSION="v1.6.0"
 ENV GOTESTDOX_VERSION="v0.2.2"
 
 # These commits/versions are provided by temporary forks of the upstream
@@ -43,7 +42,6 @@ ENV GOTESTDOX_VERSION="v0.2.2"
 ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
 ENV STRUCTSLOP_VERSION="33c868804e9e6070fdaee64b729d3129bbe85a53"
 ENV TICKERYZER_VERSION="b38acaa6d76d30629a49ad9eddd1aa5ddd0afa8f"
-# ENV ERRWRAP_VERSION="c75521dd38c3bf43d1acaf3f628d87252fa69270"
 
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
@@ -88,17 +86,6 @@ RUN echo "Installing tickeryzer from temporary fork" \
     && go install ./cmd/tickeryzer \
     && go version -m $(which tickeryzer) \
     && cd ..
-
-RUN echo "Installing errwrap@${ERRWRAP_VERSION}" \
-    && go install github.com/fatih/errwrap@${ERRWRAP_VERSION} \
-    && go version -m $(which errwrap)
-
-# RUN echo "Installing errwrap from temporary fork" \
-#     && git clone https://github.com/atc0005/errwrap \
-#     && cd errwrap \
-#     && git checkout ${ERRWRAP_VERSION} \
-#     && go install . \
-#     && cd ..
 
 # RUN echo "Installing golangci-lint from dev feat/go1.23 branch" \
 #     && git clone https://github.com/atc0005/golangci-lint \
@@ -150,7 +137,6 @@ ENV GOVULNCHECK_VERSION="v1.1.4"
 # ENV STRUCTSLOP_VERSION="v0.0.8"
 # ENV TICKERYZER_VERSION="v0.0.3"
 ENV TOMLL_VERSION="v2.2.3"
-ENV ERRWRAP_VERSION="v1.6.0"
 ENV GOTESTDOX_VERSION="v0.2.2"
 
 # These commits/versions are provided by temporary forks of the upstream
@@ -181,7 +167,6 @@ COPY --from=builder /go/bin/httperroryzer /usr/bin/httperroryzer
 COPY --from=builder /go/bin/structslop /usr/bin/structslop
 COPY --from=builder /go/bin/tickeryzer /usr/bin/tickeryzer
 COPY --from=builder /go/bin/tomll /usr/bin/tomll
-COPY --from=builder /go/bin/errwrap /usr/bin/errwrap
 
 # Copy over linting config files to root of container image to serve as a
 # default. Projects bringing their own config files (e.g., via GitHub Actions)


### PR DESCRIPTION
## Overview

- drop references to linter from README
- remove from `oldstable`, `stable` and `unstable` images
- remove from `tools/*` files so that we're no longer tracking potential future releases of linter

## References

- fixes GH-1842
- https://github.com/atc0005/shared-project-resources/issues/217