### PR TITLE
Remove abandoned orijtech/httperroryzer linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,6 @@ Unless indicated otherwise, the following linting tools are included in the
 | [`deadcode`](https://pkg.go.dev/golang.org/x/tools/cmd/deadcode)      | `v0.29.0`             |
 | [`pelletier/go-toml`](https://github.com/pelletier/go-toml)           | `v2.2.3`              |
 
-Forks:
-
-| Linter                                                               | Version                                    |
-| -------------------------------------------------------------------- | ------------------------------------------ |
-| [`orijtech/httperroryzer`](https://github.com/atc0005/httperroryzer) | `9f94717820d4a5075117680de2ca07875d32c9f1` |
-
 ## Build tools included
 
 The following build tools are included in all `*-build*` images *except* for
@@ -426,7 +420,6 @@ each release of this project.
     - [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)
     - [deadcode](https://pkg.go.dev/golang.org/x/tools/cmd/deadcode)
   - Additional
-    - [orijtech/httperroryzer](https://github.com/orijtech/httperroryzer)
     - [pelletier/go-toml](https://github.com/pelletier/go-toml)
 - Build Tools
   - [tc-hib/go-winres](https://github.com/tc-hib/go-winres)

--- a/oldstable/combined/Dockerfile
+++ b/oldstable/combined/Dockerfile
@@ -19,14 +19,8 @@ ENV GOLANGCI_LINT_VERSION="v1.63.4"
 ENV STATICCHECK_VERSION="v0.5.1"
 ENV DEADCODE_VERSION="v0.29.0"
 ENV GOVULNCHECK_VERSION="v1.1.4"
-# ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV TOMLL_VERSION="v2.2.3"
 ENV GOTESTDOX_VERSION="v0.2.2"
-
-# These commits/versions are provided by temporary forks of the upstream
-# projects. The plan is to switch back to current upstream vesions once
-# the required dependencies are updated for those upstream projects.
-ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
 
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
@@ -47,14 +41,6 @@ RUN echo "Installing tomll@${TOMLL_VERSION}" \
 RUN echo "Installing gotestdox@${GOTESTDOX_VERSION}" \
     && go install github.com/bitfield/gotestdox/cmd/gotestdox@${GOTESTDOX_VERSION} \
     && go version -m $(which gotestdox)
-
-RUN echo "Installing httperroryzer from temporary fork" \
-    && git clone https://github.com/atc0005/httperroryzer \
-    && cd httperroryzer \
-    && git checkout ${HTTPERRORYZER_VERSION} \
-    && go install ./cmd/httperroryzer \
-    && go version -m $(which httperroryzer) \
-    && cd ..
 
 # RUN echo "Installing golangci-lint from dev feat/go1.20 branch" \
 #     && git clone https://github.com/atc0005/golangci-lint \
@@ -94,12 +80,6 @@ ENV DEADCODE_VERSION="v0.29.0"
 ENV GOVULNCHECK_VERSION="v1.1.4"
 ENV TOMLL_VERSION="v2.2.3"
 ENV GOTESTDOX_VERSION="v0.2.2"
-
-# These commits/versions are provided by temporary forks of the upstream
-# projects. The plan is to switch back to current upstream vesions once
-# the required dependencies are updated for those upstream projects.
-ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
-
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
 ENV APT_FILE_VERSION="1:5.44-3"
@@ -117,7 +97,6 @@ COPY --from=builder /go/bin/golangci-lint /usr/bin/golangci-lint
 COPY --from=builder /go/bin/govulncheck /usr/bin/govulncheck
 COPY --from=builder /go/bin/deadcode /usr/bin/deadcode
 COPY --from=builder /go/bin/gotestdox /usr/bin/gotestdox
-COPY --from=builder /go/bin/httperroryzer /usr/bin/httperroryzer
 COPY --from=builder /go/bin/tomll /usr/bin/tomll
 
 # Copy over linting config files to root of container image to serve as a

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -26,14 +26,8 @@ ENV GOLANGCI_LINT_VERSION="v1.63.4"
 ENV STATICCHECK_VERSION="v0.5.1"
 ENV DEADCODE_VERSION="v0.29.0"
 ENV GOVULNCHECK_VERSION="v1.1.4"
-# ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV TOMLL_VERSION="v2.2.3"
 ENV GOTESTDOX_VERSION="v0.2.2"
-
-# These commits/versions are provided by temporary forks of the upstream
-# projects. The plan is to switch back to current upstream vesions once
-# the required dependencies are updated for those upstream projects.
-ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
 
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
@@ -58,14 +52,6 @@ RUN echo "Installing tomll@${TOMLL_VERSION}" \
 RUN echo "Installing gotestdox@${GOTESTDOX_VERSION}" \
     && go install github.com/bitfield/gotestdox/cmd/gotestdox@${GOTESTDOX_VERSION} \
     && go version -m $(which gotestdox)
-
-RUN echo "Installing httperroryzer from temporary fork" \
-    && git clone https://github.com/atc0005/httperroryzer \
-    && cd httperroryzer \
-    && git checkout ${HTTPERRORYZER_VERSION} \
-    && go install ./cmd/httperroryzer \
-    && go version -m $(which httperroryzer) \
-    && cd ..
 
 # RUN echo "Installing golangci-lint from dev feat/go1.20 branch" \
 #     && git clone https://github.com/atc0005/golangci-lint \
@@ -112,15 +98,8 @@ ENV STATICCHECK_VERSION="v0.5.1"
 
 ENV DEADCODE_VERSION="v0.29.0"
 ENV GOVULNCHECK_VERSION="v1.1.4"
-# ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV TOMLL_VERSION="v2.2.3"
 ENV GOTESTDOX_VERSION="v0.2.2"
-
-# These commits/versions are provided by temporary forks of the upstream
-# projects. The plan is to switch back to current upstream vesions once
-# the required dependencies are updated for those upstream projects.
-ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
-
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
 ENV APT_FILE_VERSION="1:5.44-3"
@@ -138,7 +117,6 @@ COPY --from=builder /go/bin/golangci-lint /usr/bin/golangci-lint
 COPY --from=builder /go/bin/govulncheck /usr/bin/govulncheck
 COPY --from=builder /go/bin/deadcode /usr/bin/deadcode
 COPY --from=builder /go/bin/gotestdox /usr/bin/gotestdox
-COPY --from=builder /go/bin/httperroryzer /usr/bin/httperroryzer
 COPY --from=builder /go/bin/tomll /usr/bin/tomll
 
 # Copy over linting config files to root of container image to serve as a

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -12,9 +12,6 @@ require (
 	// golangci-lint - intended as a primary linter
 	github.com/golangci/golangci-lint v1.63.4
 
-	// httperroryzer - provided as an optional linter
-	github.com/orijtech/httperroryzer v0.0.1
-
 	// tomll - provided as an optional linter
 	github.com/pelletier/go-toml/v2 v2.2.3
 

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -137,8 +137,6 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/orijtech/httperroryzer v0.0.1 h1:85v2h0lGsa4X1DvOpuMmR+mimG7bGYYRbOWTmE/YOi4=
-github.com/orijtech/httperroryzer v0.0.1/go.mod h1:j1TGk7yN1XWUoNrjJTs8V+FNmonAdmfjJJvbt2fOTxs=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -14,7 +14,6 @@ import (
 	_ "github.com/choffmeister/git-describe-semver"
 	_ "github.com/golangci/golangci-lint/pkg/config"
 	_ "github.com/goreleaser/nfpm/v2"
-	_ "github.com/orijtech/httperroryzer"
 	_ "github.com/pelletier/go-toml/v2"
 	_ "github.com/tc-hib/go-winres"
 	_ "golang.org/x/tools/cmd/deadcode"

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -30,14 +30,8 @@ ENV STATICCHECK_VERSION="v0.5.1"
 
 ENV DEADCODE_VERSION="v0.29.0"
 ENV GOVULNCHECK_VERSION="v1.1.4"
-# ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV TOMLL_VERSION="v2.2.3"
 ENV GOTESTDOX_VERSION="v0.2.2"
-
-# These commits/versions are provided by temporary forks of the upstream
-# projects. The plan is to switch back to current upstream vesions once
-# the required dependencies are updated for those upstream projects.
-ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
 
 RUN echo "Installing staticcheck@${STATICCHECK_VERSION}" \
     && go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION} \
@@ -58,13 +52,6 @@ RUN echo "Installing tomll@${TOMLL_VERSION}" \
 RUN echo "Installing gotestdox@${GOTESTDOX_VERSION}" \
     && go install github.com/bitfield/gotestdox/cmd/gotestdox@${GOTESTDOX_VERSION} \
     && go version -m $(which gotestdox)
-
-RUN echo "Installing httperroryzer from temporary fork" \
-    && git clone https://github.com/atc0005/httperroryzer \
-    && cd httperroryzer \
-    && git checkout ${HTTPERRORYZER_VERSION} \
-    && go install ./cmd/httperroryzer \
-    && cd ..
 
 # RUN echo "Installing golangci-lint from dev feat/go1.23 branch" \
 #     && git clone https://github.com/atc0005/golangci-lint \
@@ -112,15 +99,8 @@ ENV STATICCHECK_VERSION="v0.5.1"
 
 ENV DEADCODE_VERSION="v0.29.0"
 ENV GOVULNCHECK_VERSION="v1.1.4"
-# ENV HTTPERRORYZER_VERSION="v0.0.1"
 ENV TOMLL_VERSION="v2.2.3"
 ENV GOTESTDOX_VERSION="v0.2.2"
-
-# These commits/versions are provided by temporary forks of the upstream
-# projects. The plan is to switch back to current upstream vesions once
-# the required dependencies are updated for those upstream projects.
-ENV HTTPERRORYZER_VERSION="9f94717820d4a5075117680de2ca07875d32c9f1"
-
 ENV APT_BSDMAINUTILS_VERSION="12.1.8"
 ENV APT_TREE_VERSION="2.1.0-1"
 ENV APT_FILE_VERSION="1:5.44-3"
@@ -138,7 +118,6 @@ COPY --from=builder /go/bin/golangci-lint /usr/bin/golangci-lint
 COPY --from=builder /go/bin/govulncheck /usr/bin/govulncheck
 COPY --from=builder /go/bin/deadcode /usr/bin/deadcode
 COPY --from=builder /go/bin/gotestdox /usr/bin/gotestdox
-COPY --from=builder /go/bin/httperroryzer /usr/bin/httperroryzer
 COPY --from=builder /go/bin/tomll /usr/bin/tomll
 
 # Copy over linting config files to root of container image to serve as a


### PR DESCRIPTION
## Overview

- drop references to linter from README
- remove from `oldstable`, `stable` and `unstable` images
- remove from `tools/*` files so that we're no longer tracking potential future releases of linter

## References

- fixes GH-1848
