### PR TITLE
Update unstable build images to Go 1.24rc1

### DIFF
--- a/unstable/build/alpine-x64/Dockerfile
+++ b/unstable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM amd64/golang:1.23.4-alpine3.20
+FROM amd64/golang:1.24rc1-alpine3.20
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/alpine-x86/Dockerfile
+++ b/unstable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.23.4-alpine3.20
+FROM i386/golang:1.24rc1-alpine3.20
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/cgo-mingw-w64-x64/Dockerfile
+++ b/unstable/build/cgo-mingw-w64-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM amd64/golang:1.23.4-bullseye
+FROM amd64/golang:1.24rc1-bullseye
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/cgo-mingw-w64-x86/Dockerfile
+++ b/unstable/build/cgo-mingw-w64-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/r/i386/golang
 
-FROM i386/golang:1.23.4-bullseye
+FROM i386/golang:1.24rc1-bullseye
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/release/Dockerfile
+++ b/unstable/build/release/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM amd64/golang:1.23.4-bookworm
+FROM amd64/golang:1.24rc1-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM amd64/golang:1.23.4-bookworm as builder
+FROM amd64/golang:1.23.4-bookworm AS builder
 
 # Explicitly disable automatic fetching of Go toolchains newer than the
 # version explicitly provided by this container image.
@@ -15,16 +15,25 @@ FROM amd64/golang:1.23.4-bookworm as builder
 # https://github.com/atc0005/go-ci/issues/1188
 ENV GOTOOLCHAIN="local"
 
-# A current dev branch build (mirrored to fork) is used for pre-release Go
-# versions, otherwise the latest upstream build of the tool is installed in
-# this image.
-# ENV GOLANGCI_LINT_VERSION="FORK-go1.23-support-2024-07-31"
+# A current dev branch build (tagged & mirrored to fork) is used for
+# pre-release Go versions.
+#
+# For example, a tag named `FORK-go1.24-support-2025-01-08` is used to track
+# changes in the upstream `feat/go1.24` branch (latest commit on 2025-01-08)
+# ahead of Go 1.24 being officially released (and a stable version of
+# golangci-lint released soon after).
+#
+# ENV GOLANGCI_LINT_VERSION="FORK-go1.24-support-2025-01-08"
 
-# Latest upstream
+# The latest upstream stable build of the tool is installed in this image when
+# all available Go versions are stable versions (e.g., no alpha, beta or rc
+# versions).
+#
 ENV GOLANGCI_LINT_VERSION="v1.63.4"
 
 # A current master branch build is used for pre-release Go versions, otherwise
 # the latest upstream build of the tool is installed in this image.
+#
 # ENV STATICCHECK_VERSION="dec278f2f0d94b07c04db075d807e9f499f5d7b5"
 ENV STATICCHECK_VERSION="v0.5.1"
 
@@ -66,7 +75,7 @@ RUN echo "Installing golangci-lint@${GOLANGCI_LINT_VERSION}" \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version
 
-FROM amd64/golang:1.23.4-bookworm as final
+FROM amd64/golang:1.23.4-bookworm AS final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -86,14 +95,25 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 # https://github.com/atc0005/go-ci/issues/1188
 ENV GOTOOLCHAIN="local"
 
-# A current dev branch build (mirrored to fork) is used for pre-release Go
-# versions, otherwise the latest upstream build of the tool is installed in
-# this image.
-# ENV GOLANGCI_LINT_VERSION="FORK-go1.23-support-2024-07-31"
+# A current dev branch build (tagged & mirrored to fork) is used for
+# pre-release Go versions.
+#
+# For example, a tag named `FORK-go1.24-support-2025-01-08` is used to track
+# changes in the upstream `feat/go1.24` branch (latest commit on 2025-01-08)
+# ahead of Go 1.24 being officially released (and a stable version of
+# golangci-lint released soon after).
+#
+# ENV GOLANGCI_LINT_VERSION="FORK-go1.24-support-2025-01-08"
 
-# Latest upstream
+# The latest upstream stable build of the tool is installed in this image when
+# all available Go versions are stable versions (e.g., no alpha, beta or rc
+# versions).
+#
 ENV GOLANGCI_LINT_VERSION="v1.63.4"
 
+# A current master branch build is used for pre-release Go versions, otherwise
+# the latest upstream build of the tool is installed in this image.
+#
 # ENV STATICCHECK_VERSION="dec278f2f0d94b07c04db075d807e9f499f5d7b5"
 ENV STATICCHECK_VERSION="v0.5.1"
 


### PR DESCRIPTION
The unstable build images have been updated to use the Go 1.24rc1 base image while the unstable "combined" image continues to use the `amd64/golang:1.23.4-bookworm base image for now.

Once the staticcheck and golangci-lint tools are updated to support Go 1.24 we can switch the base image for the "combined" linter image to the Go 1.24 series.

- fixes GH-1831