### PR TITLE
Fix base image for cgo-mingw-w64-x64

### DIFF
--- a/stable/build/cgo-mingw-w64-x64/Dockerfile
+++ b/stable/build/cgo-mingw-w64-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM amd64/golang:1.22.6-bullseye
+FROM amd64/golang:1.23.5-bullseye
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
This looks to have been missed for the Go 1.22 to 1.23 switchover as part of the v0.21.9 release.