### PR TITLE
Fix constraints for stable cgo-mingw-w64-x64

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -354,7 +354,7 @@ updates:
     ignore:
       - dependency-name: "amd64/golang"
         versions:
-          - ">= 1.22"
+          - ">= 1.24"
           - "< 1.23"
 
   - package-ecosystem: docker


### PR DESCRIPTION
This was unintentionally busted while switching from the Go 1.22 series to Go 1.23.

refs GH-1663