### PR TITLE
Replace `exportloopref` linter with `copyloopvar`

### DIFF
--- a/oldstable/combined/.golangci.yml
+++ b/oldstable/combined/.golangci.yml
@@ -29,7 +29,7 @@ linters:
     # - depguard
     - dogsled
     - dupl
-    - exportloopref
+    - copyloopvar
     - goconst
     - gocritic
     - gofmt

--- a/stable/combined/.golangci.yml
+++ b/stable/combined/.golangci.yml
@@ -29,7 +29,7 @@ linters:
     # - depguard
     - dogsled
     - dupl
-    - exportloopref
+    - copyloopvar
     - goconst
     - gocritic
     - gofmt

--- a/unstable/combined/.golangci.yml
+++ b/unstable/combined/.golangci.yml
@@ -38,7 +38,7 @@ linters:
     - dupl
     - err113
     - errcheck
-    - exportloopref
+    - copyloopvar
     - gochecknoglobals
     - gocognit
     - goconst


### PR DESCRIPTION
Recent golangci-lint linter refuses to run with deprecated linter referenced in "combined" image `.golangci.yml` config file.

fixes GH-1942