### PR TITLE
tools go.mod: update minimum Go version to 1.23.0

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,7 +1,7 @@
 module github.com/atc0005/go-ci/tools
 
 // Use the current oldstable Go version
-go 1.23
+go 1.23.0
 require (
 	// govulncheck - provided as an optional testing utility
 	// https://pkg.go.dev/github.com/bitfield/gotestdox?tab=versions


### PR DESCRIPTION
Update from 1.23 to 1.23.0 to match changes to golang.org/x repos and (hopefully) prevent `toolchain` annotations.