### PR TITLE
Swap Alpine base image version from 3.20 to 3.22

### DIFF
--- a/oldstable/build/alpine-x64/Dockerfile
+++ b/oldstable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM amd64/golang:1.23.9-alpine3.20
+FROM amd64/golang:1.23.10-alpine3.22
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/oldstable/build/alpine-x64/Dockerfile
+++ b/oldstable/build/alpine-x64/Dockerfile
@@ -28,18 +28,25 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 # https://github.com/atc0005/go-ci/issues/1188
 ENV GOTOOLCHAIN="local"
 
-# NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="13.2.0-r2"
+################################################################################################
+# For updating the versions below:
+#
+# podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
+# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+################################################################################################
 
-ENV APK_BASH_VERSION="5.2.26-r0"
-ENV APK_GCC_VERSION="13.2.1_git20240309-r1"
-ENV APK_GIT_VERSION="2.45.3-r0"
-ENV APK_MAKE_VERSION="4.4.1-r2"
-ENV APK_UTIL_LINUX_VERSION="2.40.1-r1"
-ENV APK_FILE_VERSION="5.45-r1"
-ENV APK_NANO_VERSION="8.0-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r1"
-ENV APK_XZ_VERSION="5.6.2-r1"
+# NOTE: This version is often different than the base `gcc` package.
+ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+
+ENV APK_BASH_VERSION="5.2.37-r0"
+ENV APK_GCC_VERSION="14.2.0-r6"
+ENV APK_GIT_VERSION="2.49.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r3"
+ENV APK_UTIL_LINUX_VERSION="2.41-r9"
+ENV APK_FILE_VERSION="5.46-r2"
+ENV APK_NANO_VERSION="8.4-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.5-r10"
+ENV APK_XZ_VERSION="5.8.1-r0"
 
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.3"

--- a/oldstable/build/alpine-x86/Dockerfile
+++ b/oldstable/build/alpine-x86/Dockerfile
@@ -27,18 +27,25 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 # https://github.com/atc0005/go-ci/issues/1188
 ENV GOTOOLCHAIN="local"
 
-# NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="13.2.0-r2"
+################################################################################################
+# For updating the versions below:
+#
+# podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
+# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+################################################################################################
 
-ENV APK_BASH_VERSION="5.2.26-r0"
-ENV APK_GCC_VERSION="13.2.1_git20240309-r1"
-ENV APK_GIT_VERSION="2.45.3-r0"
-ENV APK_MAKE_VERSION="4.4.1-r2"
-ENV APK_UTIL_LINUX_VERSION="2.40.1-r1"
-ENV APK_FILE_VERSION="5.45-r1"
-ENV APK_NANO_VERSION="8.0-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r1"
-ENV APK_XZ_VERSION="5.6.2-r1"
+# NOTE: This version is often different than the base `gcc` package.
+ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+
+ENV APK_BASH_VERSION="5.2.37-r0"
+ENV APK_GCC_VERSION="14.2.0-r6"
+ENV APK_GIT_VERSION="2.49.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r3"
+ENV APK_UTIL_LINUX_VERSION="2.41-r9"
+ENV APK_FILE_VERSION="5.46-r2"
+ENV APK_NANO_VERSION="8.4-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.5-r10"
+ENV APK_XZ_VERSION="5.8.1-r0"
 
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.3"

--- a/oldstable/build/alpine-x86/Dockerfile
+++ b/oldstable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.23.9-alpine3.20
+FROM i386/golang:1.23.10-alpine3.22
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -28,18 +28,25 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 # https://github.com/atc0005/go-ci/issues/1188
 ENV GOTOOLCHAIN="local"
 
-# NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="13.2.0-r2"
+################################################################################################
+# For updating the versions below:
+#
+# podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
+# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+################################################################################################
 
-ENV APK_BASH_VERSION="5.2.26-r0"
-ENV APK_GCC_VERSION="13.2.1_git20240309-r1"
-ENV APK_GIT_VERSION="2.45.3-r0"
-ENV APK_MAKE_VERSION="4.4.1-r2"
-ENV APK_UTIL_LINUX_VERSION="2.40.1-r1"
-ENV APK_FILE_VERSION="5.45-r1"
-ENV APK_NANO_VERSION="8.0-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r1"
-ENV APK_XZ_VERSION="5.6.2-r1"
+# NOTE: This version is often different than the base `gcc` package.
+ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+
+ENV APK_BASH_VERSION="5.2.37-r0"
+ENV APK_GCC_VERSION="14.2.0-r6"
+ENV APK_GIT_VERSION="2.49.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r3"
+ENV APK_UTIL_LINUX_VERSION="2.41-r9"
+ENV APK_FILE_VERSION="5.46-r2"
+ENV APK_NANO_VERSION="8.4-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.5-r10"
+ENV APK_XZ_VERSION="5.8.1-r0"
 
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.3"

--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM amd64/golang:1.24.3-alpine3.20
+FROM amd64/golang:1.24.4-alpine3.22
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -27,18 +27,30 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 # https://github.com/atc0005/go-ci/issues/1188
 ENV GOTOOLCHAIN="local"
 
-# NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="13.2.0-r2"
+################################################################################################
+# For updating the versions below:
+#
+# podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
+# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+################################################################################################
 
-ENV APK_BASH_VERSION="5.2.26-r0"
-ENV APK_GCC_VERSION="13.2.1_git20240309-r1"
-ENV APK_GIT_VERSION="2.45.3-r0"
-ENV APK_MAKE_VERSION="4.4.1-r2"
-ENV APK_UTIL_LINUX_VERSION="2.40.1-r1"
-ENV APK_FILE_VERSION="5.45-r1"
-ENV APK_NANO_VERSION="8.0-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r1"
-ENV APK_XZ_VERSION="5.6.2-r1"
+# NOTE: This version is often different than the base `gcc` package.
+ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+
+ENV APK_BASH_VERSION="5.2.37-r0"
+ENV APK_GCC_VERSION="14.2.0-r6"
+ENV APK_GIT_VERSION="2.49.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r3"
+ENV APK_UTIL_LINUX_VERSION="2.41-r9"
+ENV APK_FILE_VERSION="5.46-r2"
+ENV APK_NANO_VERSION="8.4-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.5-r10"
+ENV APK_XZ_VERSION="5.8.1-r0"
+
+# For updating the versions above:
+#
+# podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
+# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
 
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.3"

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.24.3-alpine3.20
+FROM i386/golang:1.24.4-alpine3.22
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/alpine-x64/Dockerfile
+++ b/unstable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM amd64/golang:1.24.3-alpine3.20
+FROM amd64/golang:1.24.4-alpine3.22
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/alpine-x64/Dockerfile
+++ b/unstable/build/alpine-x64/Dockerfile
@@ -28,18 +28,30 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 # https://github.com/atc0005/go-ci/issues/1188
 ENV GOTOOLCHAIN="local"
 
-# NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="13.2.0-r2"
+################################################################################################
+# For updating the versions below:
+#
+# podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
+# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+################################################################################################
 
-ENV APK_BASH_VERSION="5.2.26-r0"
-ENV APK_GCC_VERSION="13.2.1_git20240309-r1"
-ENV APK_GIT_VERSION="2.45.3-r0"
-ENV APK_MAKE_VERSION="4.4.1-r2"
-ENV APK_UTIL_LINUX_VERSION="2.40.1-r1"
-ENV APK_FILE_VERSION="5.45-r1"
-ENV APK_NANO_VERSION="8.0-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r1"
-ENV APK_XZ_VERSION="5.6.2-r1"
+# NOTE: This version is often different than the base `gcc` package.
+ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+
+ENV APK_BASH_VERSION="5.2.37-r0"
+ENV APK_GCC_VERSION="14.2.0-r6"
+ENV APK_GIT_VERSION="2.49.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r3"
+ENV APK_UTIL_LINUX_VERSION="2.41-r9"
+ENV APK_FILE_VERSION="5.46-r2"
+ENV APK_NANO_VERSION="8.4-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.5-r10"
+ENV APK_XZ_VERSION="5.8.1-r0"
+
+# For updating the versions above:
+#
+# podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
+# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
 
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.3"

--- a/unstable/build/alpine-x86/Dockerfile
+++ b/unstable/build/alpine-x86/Dockerfile
@@ -28,18 +28,25 @@ LABEL org.opencontainers.image.authors="Adam Chalkley (github.com/atc0005)"
 # https://github.com/atc0005/go-ci/issues/1188
 ENV GOTOOLCHAIN="local"
 
-# NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="13.2.0-r2"
+################################################################################################
+# For updating the versions below:
+#
+# podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
+# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+################################################################################################
 
-ENV APK_BASH_VERSION="5.2.26-r0"
-ENV APK_GCC_VERSION="13.2.1_git20240309-r1"
-ENV APK_GIT_VERSION="2.45.3-r0"
-ENV APK_MAKE_VERSION="4.4.1-r2"
-ENV APK_UTIL_LINUX_VERSION="2.40.1-r1"
-ENV APK_FILE_VERSION="5.45-r1"
-ENV APK_NANO_VERSION="8.0-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r1"
-ENV APK_XZ_VERSION="5.6.2-r1"
+# NOTE: This version is often different than the base `gcc` package.
+ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+
+ENV APK_BASH_VERSION="5.2.37-r0"
+ENV APK_GCC_VERSION="14.2.0-r6"
+ENV APK_GIT_VERSION="2.49.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r3"
+ENV APK_UTIL_LINUX_VERSION="2.41-r9"
+ENV APK_FILE_VERSION="5.46-r2"
+ENV APK_NANO_VERSION="8.4-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.5-r10"
+ENV APK_XZ_VERSION="5.8.1-r0"
 
 # https://github.com/tc-hib/go-winres/releases
 ENV GO_WINRES_VERSION="v0.3.3"

--- a/unstable/build/alpine-x86/Dockerfile
+++ b/unstable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.24.3-alpine3.20
+FROM i386/golang:1.24.4-alpine3.22
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
## Changes

- update base image version to reflect upstream retirement of the 3.20 image
- update pinned Alpine package versions to reflect base image version update

## References

- fixes GH-2059