### PR TITLE
Update Go 1.25 image refs to fixed 1.25.0 release

### DIFF
--- a/unstable/build/alpine-x64/Dockerfile
+++ b/unstable/build/alpine-x64/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM amd64/golang:1.25-alpine3.22
+FROM amd64/golang:1.25.0-alpine3.22
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/alpine-x86/Dockerfile
+++ b/unstable/build/alpine-x86/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM i386/golang:1.25-alpine3.22
+FROM i386/golang:1.25.0-alpine3.22
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/release/Dockerfile
+++ b/unstable/build/release/Dockerfile
@@ -7,7 +7,7 @@
 
 # https://hub.docker.com/_/golang
 
-FROM amd64/golang:1.25-bookworm
+FROM amd64/golang:1.25.0-bookworm
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
## Changes

The applied Dependabot PRs bumped Go 1.25rc3 image refs to the Go 1.25 series (whatever happens to be the latest available) instead of the desired fixed x.y.Z point release (i.e., `1.25` instead of `1.25.0`).

This commit updates those entries to explicitly reference the current point release of `1.25.0`.

# References

- GH-2135
- GH-2136
- GH-2137