### PR TITLE
Update Dependabot monitoring for Go 1.25 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,10 +90,10 @@ updates:
       - dependency-name: "amd64/golang"
         versions:
           # Greater than or equal to stable container image series
-          - ">= 1.24"
+          - ">= 1.25"
 
           # Less than oldstable series
-          - "< 1.23"
+          - "< 1.24"
     assignees:
       - "atc0005"
     labels:
@@ -120,10 +120,10 @@ updates:
       - dependency-name: "amd64/golang"
         versions:
           # Greater than or equal to stable container image series
-          - ">= 1.24"
+          - ">= 1.25"
 
           # Less than oldstable series
-          - "< 1.23"
+          - "< 1.24"
     assignees:
       - "atc0005"
     labels:
@@ -157,10 +157,10 @@ updates:
       - dependency-name: "amd64/golang"
         versions:
           # Greater than or equal to stable container image series
-          - ">= 1.24"
+          - ">= 1.25"
 
           # Less than oldstable series
-          - "< 1.23"
+          - "< 1.24"
 
   - package-ecosystem: docker
     directory: "/oldstable/build/alpine-x86"
@@ -184,10 +184,10 @@ updates:
       - dependency-name: "i386/golang"
         versions:
           # Greater than or equal to stable container image series
-          - ">= 1.24"
+          - ">= 1.25"
 
           # Less than oldstable series
-          - "< 1.23"
+          - "< 1.24"
 
   - package-ecosystem: docker
     directory: "/stable/combined"
@@ -210,8 +210,8 @@ updates:
     ignore:
       - dependency-name: "amd64/golang"
         versions:
-          - ">= 1.25"
-          - "< 1.24"
+          - ">= 1.26"
+          - "< 1.25"
 
   - package-ecosystem: docker
     directory: "/stable/build/alpine-x64"
@@ -234,8 +234,8 @@ updates:
     ignore:
       - dependency-name: "amd64/golang"
         versions:
-          - ">= 1.25"
-          - "< 1.24"
+          - ">= 1.26"
+          - "< 1.25"
 
   - package-ecosystem: docker
     directory: "/stable/build/alpine-x86"
@@ -258,8 +258,8 @@ updates:
     ignore:
       - dependency-name: "i386/golang"
         versions:
-          - ">= 1.25"
-          - "< 1.24"
+          - ">= 1.26"
+          - "< 1.25"
 
   - package-ecosystem: docker
     directory: "/unstable/build/alpine-x64"
@@ -320,8 +320,8 @@ updates:
     ignore:
       - dependency-name: "amd64/golang"
         versions:
-          - ">= 1.24"
-          - "< 1.23"
+          - ">= 1.25"
+          - "< 1.24"
 
   - package-ecosystem: docker
     directory: "/oldstable/build/cgo-mingw-w64-x86"
@@ -344,8 +344,8 @@ updates:
     ignore:
       - dependency-name: "i386/golang"
         versions:
-          - ">= 1.24"
-          - "< 1.23"
+          - ">= 1.25"
+          - "< 1.24"
 
   - package-ecosystem: docker
     directory: "/stable/build/cgo-mingw-w64-x64"
@@ -368,8 +368,8 @@ updates:
     ignore:
       - dependency-name: "amd64/golang"
         versions:
-          - ">= 1.25"
-          - "< 1.24"
+          - ">= 1.26"
+          - "< 1.25"
 
   - package-ecosystem: docker
     directory: "/stable/build/cgo-mingw-w64-x86"
@@ -392,8 +392,8 @@ updates:
     ignore:
       - dependency-name: "i386/golang"
         versions:
-          - ">= 1.25"
-          - "< 1.24"
+          - ">= 1.26"
+          - "< 1.25"
 
   - package-ecosystem: docker
     directory: "/unstable/build/cgo-mingw-w64-x64"
@@ -454,32 +454,8 @@ updates:
     ignore:
       - dependency-name: "amd64/golang"
         versions:
-          - ">= 1.25"
-          - "< 1.24"
-
-  - package-ecosystem: docker
-    directory: "/mirror/1.23"
-    open-pull-requests-limit: 10
-    target-branch: "master"
-    schedule:
-      interval: "daily"
-      time: "02:00"
-      timezone: "America/Chicago"
-    assignees:
-      - "atc0005"
-    labels:
-      - "dependencies"
-      - "CI"
-    allow:
-      - dependency-type: "all"
-    commit-message:
-      prefix: "Mirror Build Image"
-    rebase-strategy: "disabled"
-    ignore:
-      - dependency-name: "amd64/golang"
-        versions:
-          - ">= 1.24"
-          - "< 1.23"
+          - ">= 1.26"
+          - "< 1.25"
 
   - package-ecosystem: docker
     directory: "/mirror/1.24"
@@ -504,6 +480,30 @@ updates:
         versions:
           - ">= 1.25"
           - "< 1.24"
+
+  - package-ecosystem: docker
+    directory: "/mirror/1.25"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "CI"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "Mirror Build Image"
+    rebase-strategy: "disabled"
+    ignore:
+      - dependency-name: "amd64/golang"
+        versions:
+          - ">= 1.26"
+          - "< 1.25"
 
   - package-ecosystem: docker
     directory: "/unstable/build/release"


### PR DESCRIPTION
- add monitoring for Go 1.25 mirror image
- remove monitoring for Go 1.23 mirror image
- update Dependabot Docker image version constraints
  - update upper/lower series for oldstable images
  - update upper/lower series for stable images

The unstable image version constraint settings continue to permit updating to the latest available.