### PR TITLE
Fix golangci-lint install URL

### DIFF
--- a/oldstable/combined/Dockerfile
+++ b/oldstable/combined/Dockerfile
@@ -56,7 +56,7 @@ RUN echo "Installing gotestdox@${GOTESTDOX_VERSION}" \
 
 RUN echo "Installing golangci-lint@${GOLANGCI_LINT_VERSION}" \
     && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
-    && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+    && curl -sSfLO https://golangci-lint.run/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version
 

--- a/stable/combined/Dockerfile
+++ b/stable/combined/Dockerfile
@@ -62,7 +62,7 @@ RUN echo "Installing gotestdox@${GOTESTDOX_VERSION}" \
 
 RUN echo "Installing golangci-lint@${GOLANGCI_LINT_VERSION}" \
     && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
-    && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+    && curl -sSfLO https://golangci-lint.run/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version
 

--- a/unstable/combined/Dockerfile
+++ b/unstable/combined/Dockerfile
@@ -71,7 +71,7 @@ RUN echo "Installing gotestdox@${GOTESTDOX_VERSION}" \
 
 RUN echo "Installing golangci-lint@${GOLANGCI_LINT_VERSION}" \
     && echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}" \
-    && curl -sSfLO https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+    && curl -sSfLO https://golangci-lint.run/install.sh \
     && sh install.sh -b "$(go env GOPATH)/bin" ${GOLANGCI_LINT_VERSION} \
     && golangci-lint --version
 


### PR DESCRIPTION
Switch from using `raw.githubusercontent.com` `master` branch to using official recommendation to use `golangci-lint.run` as the install source.

refs GH-2461