### PR TITLE
Update upstream i386 images ref link URL

### DIFF
--- a/oldstable/build/alpine-x86/Dockerfile
+++ b/oldstable/build/alpine-x86/Dockerfile
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.
 
-# https://hub.docker.com/_/golang
+# https://hub.docker.com/r/i386/golang
 
 # Use latest stable version to compile build tools as static binaries for
 # inclusion in "final" image stage for use with oldstable build environment.

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.
 
-# https://hub.docker.com/_/golang
+# https://hub.docker.com/r/i386/golang
 
 FROM i386/golang:1.26.2-alpine3.22 AS builder
 

--- a/unstable/build/alpine-x86/Dockerfile
+++ b/unstable/build/alpine-x86/Dockerfile
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.
 
-# https://hub.docker.com/_/golang
+# https://hub.docker.com/r/i386/golang
 
 FROM i386/golang:1.26.2-alpine3.22 AS builder
 


### PR DESCRIPTION
Replace general Docker Hub upstream images listing URL with one specific to i386 images.

Most i386 Dockerfiles in this project already had the correct URL. This commit updates the remaining files to include it.