### PR TITLE
Swap Alpine base image version from 3.22 to 3.24

### DIFF
--- a/oldstable/build/alpine-x64/Dockerfile
+++ b/oldstable/build/alpine-x64/Dockerfile
@@ -20,7 +20,7 @@
 # the duration of the "oldstable" Go series providing Go 1.24.
 #
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM amd64/golang:alpine3.22@sha256:19d1696b750f1d42f0e86fc598b9710143e8314c574038326dc46fa9b166940d AS builder
+FROM amd64/golang:alpine3.24@sha256:111d79159b2326f7e80c4a4706e1ba166acb0e2611df853955f3621828cd49e8 AS builder
 
 # Explicitly disable automatic fetching of Go toolchains newer than the
 # version explicitly provided by this container image.
@@ -51,7 +51,7 @@ RUN echo "Installing git-describe-semver@${GIT_DESCRIBE_SEMVER_VERSION}" \
 
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM amd64/golang:1.25.11-alpine3.22@sha256:fba8ff6240b0a3fac05e41c09bbca16212e7e8cca01c5c888e1246a9b5b88680 AS final
+FROM amd64/golang:1.25.11-alpine3.24@sha256:1abaac8805a62aa7656048c198447c6841905926b247a04e4cca9ab0072ae862 AS final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/oldstable/build/alpine-x64/Dockerfile
+++ b/oldstable/build/alpine-x64/Dockerfile
@@ -76,20 +76,21 @@ ENV GOTOOLCHAIN="local"
 # For updating the versions below:
 #
 # podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
-# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+# apk update
+# apk info make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz | grep description | awk '{print $1}'
 ################################################################################################
 
 # NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+ENV APK_GCC_MINGW64_VERSION="15.2.0-r0"
 
-ENV APK_BASH_VERSION="5.2.37-r0"
-ENV APK_GCC_VERSION="14.2.0-r6"
-ENV APK_GIT_VERSION="2.49.1-r0"
-ENV APK_MAKE_VERSION="4.4.1-r3"
-ENV APK_UTIL_LINUX_VERSION="2.41-r9"
-ENV APK_FILE_VERSION="5.46-r2"
-ENV APK_NANO_VERSION="8.4-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r12"
+ENV APK_BASH_VERSION="5.3.9-r1"
+ENV APK_GCC_VERSION="15.2.0-r5"
+ENV APK_GIT_VERSION="2.54.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r4"
+ENV APK_UTIL_LINUX_VERSION="2.42.1-r0"
+ENV APK_FILE_VERSION="5.47-r2"
+ENV APK_NANO_VERSION="9.1-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.6-r2"
 ENV APK_XZ_VERSION="5.8.3-r0"
 
 # https://github.com/tc-hib/go-winres/releases

--- a/oldstable/build/alpine-x86/Dockerfile
+++ b/oldstable/build/alpine-x86/Dockerfile
@@ -75,20 +75,21 @@ ENV GOTOOLCHAIN="local"
 # For updating the versions below:
 #
 # podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
-# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+# apk update
+# apk info make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz | grep description | awk '{print $1}'
 ################################################################################################
 
 # NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+ENV APK_GCC_MINGW64_VERSION="15.2.0-r0"
 
-ENV APK_BASH_VERSION="5.2.37-r0"
-ENV APK_GCC_VERSION="14.2.0-r6"
-ENV APK_GIT_VERSION="2.49.1-r0"
-ENV APK_MAKE_VERSION="4.4.1-r3"
-ENV APK_UTIL_LINUX_VERSION="2.41-r9"
-ENV APK_FILE_VERSION="5.46-r2"
-ENV APK_NANO_VERSION="8.4-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r12"
+ENV APK_BASH_VERSION="5.3.9-r1"
+ENV APK_GCC_VERSION="15.2.0-r5"
+ENV APK_GIT_VERSION="2.54.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r4"
+ENV APK_UTIL_LINUX_VERSION="2.42.1-r0"
+ENV APK_FILE_VERSION="5.47-r2"
+ENV APK_NANO_VERSION="9.1-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.6-r2"
 ENV APK_XZ_VERSION="5.8.3-r0"
 
 # https://github.com/tc-hib/go-winres/releases

--- a/oldstable/build/alpine-x86/Dockerfile
+++ b/oldstable/build/alpine-x86/Dockerfile
@@ -20,7 +20,7 @@
 # the duration of the "oldstable" Go series providing Go 1.24.
 #
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM i386/golang:alpine3.22@sha256:a9dfc12b2619d411501ab7abcbd88a27f386c2300ba33e5224e8c0c43e2cf2be AS builder
+FROM i386/golang:alpine3.24@sha256:739b5c7c89c2ba19b5744fab836efe973158e2c4b08808e99285f735af3e2926 AS builder
 
 # Explicitly disable automatic fetching of Go toolchains newer than the
 # version explicitly provided by this container image.
@@ -51,7 +51,7 @@ RUN echo "Installing git-describe-semver@${GIT_DESCRIBE_SEMVER_VERSION}" \
 
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM i386/golang:1.25.11-alpine3.22@sha256:046b8fa65910ac91bd21e64680a318c8a3cf6c2aff0557b5db8e0d6f557b30c9 AS final
+FROM i386/golang:1.25.11-alpine3.24@sha256:861b880b8799027c0af6d26b8863996e52f625c365853b80ead3b7b90daed8a5 AS final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -8,7 +8,7 @@
 # https://hub.docker.com/_/golang
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM amd64/golang:1.26.4-alpine3.22@sha256:19d1696b750f1d42f0e86fc598b9710143e8314c574038326dc46fa9b166940d AS builder
+FROM amd64/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS builder
 
 # Explicitly disable automatic fetching of Go toolchains newer than the
 # version explicitly provided by this container image.
@@ -39,7 +39,7 @@ RUN echo "Installing git-describe-semver@${GIT_DESCRIBE_SEMVER_VERSION}" \
 
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM amd64/golang:1.26.4-alpine3.22@sha256:19d1696b750f1d42f0e86fc598b9710143e8314c574038326dc46fa9b166940d AS final
+FROM amd64/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/alpine-x64/Dockerfile
+++ b/stable/build/alpine-x64/Dockerfile
@@ -8,7 +8,7 @@
 # https://hub.docker.com/_/golang
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM amd64/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS builder
+FROM amd64/golang:1.26.4-alpine3.24@sha256:0648ddfa35769070197ba1cdf22a16dc452caf9315e66b91791308a543baf229 AS builder
 
 # Explicitly disable automatic fetching of Go toolchains newer than the
 # version explicitly provided by this container image.
@@ -39,7 +39,7 @@ RUN echo "Installing git-describe-semver@${GIT_DESCRIBE_SEMVER_VERSION}" \
 
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM amd64/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS final
+FROM amd64/golang:1.26.4-alpine3.24@sha256:0648ddfa35769070197ba1cdf22a16dc452caf9315e66b91791308a543baf229 AS final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -64,20 +64,21 @@ ENV GOTOOLCHAIN="local"
 # For updating the versions below:
 #
 # podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
-# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+# apk update
+# apk info make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz | grep description | awk '{print $1}'
 ################################################################################################
 
 # NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+ENV APK_GCC_MINGW64_VERSION="15.2.0-r0"
 
-ENV APK_BASH_VERSION="5.2.37-r0"
-ENV APK_GCC_VERSION="14.2.0-r6"
-ENV APK_GIT_VERSION="2.49.1-r0"
-ENV APK_MAKE_VERSION="4.4.1-r3"
-ENV APK_UTIL_LINUX_VERSION="2.41-r9"
-ENV APK_FILE_VERSION="5.46-r2"
-ENV APK_NANO_VERSION="8.4-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r12"
+ENV APK_BASH_VERSION="5.3.9-r1"
+ENV APK_GCC_VERSION="15.2.0-r5"
+ENV APK_GIT_VERSION="2.54.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r4"
+ENV APK_UTIL_LINUX_VERSION="2.42.1-r0"
+ENV APK_FILE_VERSION="5.47-r2"
+ENV APK_NANO_VERSION="9.1-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.6-r2"
 ENV APK_XZ_VERSION="5.8.3-r0"
 
 # https://github.com/tc-hib/go-winres/releases

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -8,7 +8,7 @@
 # https://hub.docker.com/r/i386/golang
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM i386/golang:1.26.4-alpine3.22@sha256:a9dfc12b2619d411501ab7abcbd88a27f386c2300ba33e5224e8c0c43e2cf2be AS builder
+FROM i386/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS builder
 
 # Explicitly disable automatic fetching of Go toolchains newer than the
 # version explicitly provided by this container image.
@@ -39,7 +39,7 @@ RUN echo "Installing git-describe-semver@${GIT_DESCRIBE_SEMVER_VERSION}" \
 
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM i386/golang:1.26.4-alpine3.22@sha256:a9dfc12b2619d411501ab7abcbd88a27f386c2300ba33e5224e8c0c43e2cf2be AS final
+FROM i386/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/stable/build/alpine-x86/Dockerfile
+++ b/stable/build/alpine-x86/Dockerfile
@@ -63,20 +63,21 @@ ENV GOTOOLCHAIN="local"
 # For updating the versions below:
 #
 # podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
-# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+# apk update
+# apk info make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz | grep description | awk '{print $1}'
 ################################################################################################
 
 # NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+ENV APK_GCC_MINGW64_VERSION="15.2.0-r0"
 
-ENV APK_BASH_VERSION="5.2.37-r0"
-ENV APK_GCC_VERSION="14.2.0-r6"
-ENV APK_GIT_VERSION="2.49.1-r0"
-ENV APK_MAKE_VERSION="4.4.1-r3"
-ENV APK_UTIL_LINUX_VERSION="2.41-r9"
-ENV APK_FILE_VERSION="5.46-r2"
-ENV APK_NANO_VERSION="8.4-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r12"
+ENV APK_BASH_VERSION="5.3.9-r1"
+ENV APK_GCC_VERSION="15.2.0-r5"
+ENV APK_GIT_VERSION="2.54.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r4"
+ENV APK_UTIL_LINUX_VERSION="2.42.1-r0"
+ENV APK_FILE_VERSION="5.47-r2"
+ENV APK_NANO_VERSION="9.1-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.6-r2"
 ENV APK_XZ_VERSION="5.8.3-r0"
 
 # For updating the versions above:

--- a/unstable/build/alpine-x64/Dockerfile
+++ b/unstable/build/alpine-x64/Dockerfile
@@ -8,7 +8,7 @@
 # https://hub.docker.com/_/golang
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM amd64/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS builder
+FROM amd64/golang:1.26.4-alpine3.24@sha256:0648ddfa35769070197ba1cdf22a16dc452caf9315e66b91791308a543baf229 AS builder
 
 # Explicitly disable automatic fetching of Go toolchains newer than the
 # version explicitly provided by this container image.
@@ -39,7 +39,7 @@ RUN echo "Installing git-describe-semver@${GIT_DESCRIBE_SEMVER_VERSION}" \
 
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM amd64/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS final
+FROM amd64/golang:1.26.4-alpine3.24@sha256:0648ddfa35769070197ba1cdf22a16dc452caf9315e66b91791308a543baf229 AS final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"
@@ -64,20 +64,21 @@ ENV GOTOOLCHAIN="local"
 # For updating the versions below:
 #
 # podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
-# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+# apk update
+# apk info make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz | grep description | awk '{print $1}'
 ################################################################################################
 
 # NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+ENV APK_GCC_MINGW64_VERSION="15.2.0-r0"
 
-ENV APK_BASH_VERSION="5.2.37-r0"
-ENV APK_GCC_VERSION="14.2.0-r6"
-ENV APK_GIT_VERSION="2.49.1-r0"
-ENV APK_MAKE_VERSION="4.4.1-r3"
-ENV APK_UTIL_LINUX_VERSION="2.41-r9"
-ENV APK_FILE_VERSION="5.46-r2"
-ENV APK_NANO_VERSION="8.4-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r12"
+ENV APK_BASH_VERSION="5.3.9-r1"
+ENV APK_GCC_VERSION="15.2.0-r5"
+ENV APK_GIT_VERSION="2.54.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r4"
+ENV APK_UTIL_LINUX_VERSION="2.42.1-r0"
+ENV APK_FILE_VERSION="5.47-r2"
+ENV APK_NANO_VERSION="9.1-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.6-r2"
 ENV APK_XZ_VERSION="5.8.3-r0"
 
 # For updating the versions above:

--- a/unstable/build/alpine-x64/Dockerfile
+++ b/unstable/build/alpine-x64/Dockerfile
@@ -8,7 +8,7 @@
 # https://hub.docker.com/_/golang
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM amd64/golang:1.26.4-alpine3.22@sha256:19d1696b750f1d42f0e86fc598b9710143e8314c574038326dc46fa9b166940d AS builder
+FROM amd64/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS builder
 
 # Explicitly disable automatic fetching of Go toolchains newer than the
 # version explicitly provided by this container image.
@@ -39,7 +39,7 @@ RUN echo "Installing git-describe-semver@${GIT_DESCRIBE_SEMVER_VERSION}" \
 
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM amd64/golang:1.26.4-alpine3.22@sha256:19d1696b750f1d42f0e86fc598b9710143e8314c574038326dc46fa9b166940d AS final
+FROM amd64/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"

--- a/unstable/build/alpine-x86/Dockerfile
+++ b/unstable/build/alpine-x86/Dockerfile
@@ -64,20 +64,21 @@ ENV GOTOOLCHAIN="local"
 # For updating the versions below:
 #
 # podman container run --platform linux/amd64 --rm -it golang:1.24.4-alpine3.22
-# apk add --no-cache make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz
+# apk update
+# apk info make bash util-linux git gcc musl-dev mingw-w64-gcc nano file xz | grep description | awk '{print $1}'
 ################################################################################################
 
 # NOTE: This version is often different than the base `gcc` package.
-ENV APK_GCC_MINGW64_VERSION="14.2.0-r1"
+ENV APK_GCC_MINGW64_VERSION="15.2.0-r0"
 
-ENV APK_BASH_VERSION="5.2.37-r0"
-ENV APK_GCC_VERSION="14.2.0-r6"
-ENV APK_GIT_VERSION="2.49.1-r0"
-ENV APK_MAKE_VERSION="4.4.1-r3"
-ENV APK_UTIL_LINUX_VERSION="2.41-r9"
-ENV APK_FILE_VERSION="5.46-r2"
-ENV APK_NANO_VERSION="8.4-r0"
-ENV APK_MUSL_DEV_VERSION="1.2.5-r12"
+ENV APK_BASH_VERSION="5.3.9-r1"
+ENV APK_GCC_VERSION="15.2.0-r5"
+ENV APK_GIT_VERSION="2.54.0-r0"
+ENV APK_MAKE_VERSION="4.4.1-r4"
+ENV APK_UTIL_LINUX_VERSION="2.42.1-r0"
+ENV APK_FILE_VERSION="5.47-r2"
+ENV APK_NANO_VERSION="9.1-r0"
+ENV APK_MUSL_DEV_VERSION="1.2.6-r2"
 ENV APK_XZ_VERSION="5.8.3-r0"
 
 # https://github.com/tc-hib/go-winres/releases

--- a/unstable/build/alpine-x86/Dockerfile
+++ b/unstable/build/alpine-x86/Dockerfile
@@ -8,7 +8,7 @@
 # https://hub.docker.com/r/i386/golang
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM i386/golang:1.26.4-alpine3.22@sha256:a9dfc12b2619d411501ab7abcbd88a27f386c2300ba33e5224e8c0c43e2cf2be AS builder
+FROM i386/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS builder
 
 # Explicitly disable automatic fetching of Go toolchains newer than the
 # version explicitly provided by this container image.
@@ -39,7 +39,7 @@ RUN echo "Installing git-describe-semver@${GIT_DESCRIBE_SEMVER_VERSION}" \
 
 
 # REMINDER: Use the 'manifest digest' not the 'index digest' from the Docker Hub page.
-FROM i386/golang:1.26.4-alpine3.22@sha256:a9dfc12b2619d411501ab7abcbd88a27f386c2300ba33e5224e8c0c43e2cf2be AS final
+FROM i386/golang:1.26.4-alpine3.24@sha256:f33ee4cd42bb16e731cb7e8a1fba2b4ec562ed61ed30834580e4ac24be8ed3cf AS final
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source="https://github.com/atc0005/go-ci"


### PR DESCRIPTION
## Changes

- update base image version to reflect upstream retirement of the 3.22 image
- update packages to reflect base image version update


## References

- fixes GH-2574